### PR TITLE
feat: add navbar component for desktop layout

### DIFF
--- a/src/lib/components/NavbarComponent.svelte
+++ b/src/lib/components/NavbarComponent.svelte
@@ -1,0 +1,28 @@
+<nav>
+    <ul class="flex flex-row gap-4 items-center bg-warm-white justify-between pl-8 pr-1 py-1 rounded-xl">
+        <li>
+            <img src="src/lib/icons/upcsi.svg" alt="UP CSI Logo" class="object-contain" width="18"/>
+        </li>
+        <li>
+            <a href="/home/">Home</a>
+        </li>
+        <li>
+            <a href="/about/">About</a>
+        </li>
+        <li>
+            <a href="/team/">Team</a>
+        </li>
+        <li>
+            <a href="/events/">Events</a>
+        </li>
+        <li>
+            <a href="/projects/">Projects</a>
+        </li>
+        <li>
+            <a class="" href="/newsletter/">Newsletter</a>
+        </li>
+        <li>
+            <button class="bg-csi-blue py-2 px-5 rounded-xl">Get Started</button>
+        </li>
+    </ul>
+</nav>

--- a/src/lib/components/NavbarComponent.svelte
+++ b/src/lib/components/NavbarComponent.svelte
@@ -1,7 +1,14 @@
 <nav>
-    <ul class="flex flex-row gap-4 items-center bg-warm-white justify-between pl-8 pr-1 py-1 rounded-xl">
+    <ul
+        class="flex flex-row items-center justify-between gap-4 rounded-xl bg-warm-white py-1 pl-8 pr-1"
+    >
         <li>
-            <img src="src/lib/icons/upcsi.svg" alt="UP CSI Logo" class="object-contain" width="18"/>
+            <img
+                src="src/lib/icons/upcsi.svg"
+                alt="UP CSI Logo"
+                class="object-contain"
+                width="18"
+            />
         </li>
         <li>
             <a href="/home/">Home</a>
@@ -22,7 +29,7 @@
             <a class="" href="/newsletter/">Newsletter</a>
         </li>
         <li>
-            <button class="bg-csi-blue py-2 px-5 rounded-xl">Get Started</button>
+            <button class="rounded-xl bg-csi-blue px-5 py-2">Get Started</button>
         </li>
     </ul>
 </nav>


### PR DESCRIPTION
This PR adds a navbar component for the website (designed for desktop layout). Note that in the Figma file, it looks like the text color of the other tabs are a shade gray. I couldn't pinpoint what shade was used in the design, so I kept them as the default inherited color for now.