### PR TITLE
feat: add basic cards to "Why UP CSI?" section in home page

### DIFF
--- a/src/lib/components/CartoonCard.svelte
+++ b/src/lib/components/CartoonCard.svelte
@@ -1,9 +1,9 @@
-<div class="max-h-80 w-1/4 mb-8">
+<div class="mb-8 max-h-80 w-1/4">
     <div class="rounded-b-[50px] rounded-t-[180px] bg-csi-blue px-2 pt-5">
         <img src="src/lib/cartoon-card-placeholder.svg" alt="Corporate Cartoon" />
     </div>
     <div class="leading-6">
-        <h1 class="font-dm text-3xl text-center"><slot name="card_title" /></h1>
+        <h1 class="text-center font-dm text-3xl"><slot name="card_title" /></h1>
         <p class="text-center"><slot name="card_content" /></p>
     </div>
 </div>

--- a/src/lib/components/CartoonCard.svelte
+++ b/src/lib/components/CartoonCard.svelte
@@ -1,7 +1,9 @@
-<div class="w-96 rounded-b-[50px] rounded-t-[180px] bg-csi-blue px-2 pt-20">
-    <img src="src/lib/cartoon-card-placeholder.svg" alt="Corporate Cartoon" />
-</div>
-<div class="w-96">
-    <h1 class="font-dm text-3xl">Develop well-rounded DCS students</h1>
-    <p>with fundamental classroom learning through practical experience</p>
+<div class="max-h-80 w-1/4 mb-8">
+    <div class="rounded-b-[50px] rounded-t-[180px] bg-csi-blue px-2 pt-5">
+        <img src="src/lib/cartoon-card-placeholder.svg" alt="Corporate Cartoon" />
+    </div>
+    <div class="leading-6">
+        <h1 class="font-dm text-3xl text-center"><slot name="card_title" /></h1>
+        <p class="text-center"><slot name="card_content" /></p>
+    </div>
 </div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -2,6 +2,7 @@
     import BlueButton from '$lib/components/BlueButton.svelte';
     import Carousel from '$lib/components/Carousel.svelte';
     import ContentContainer from '$lib/components/ContentContainer.svelte';
+    import CartoonCard from '$lib/components/CartoonCard.svelte';
 </script>
 
 <section
@@ -73,7 +74,18 @@
                     time more often.
                 </p>
             </svelte:fragment>
+
+            <svelte:fragment slot="cards">
+                <CartoonCard>
+                    <svelte:fragment slot="card_content">Development</svelte:fragment>
+                </CartoonCard>
+
+                <CartoonCard>
+                    <svelte:fragment slot="card_content">Development</svelte:fragment>
+                </CartoonCard>
+            </svelte:fragment>
         </ContentContainer>
+
         <ContentContainer>
             <svelte:fragment slot="text">
                 <h2 class="m-0 font-dm">For students</h2>
@@ -84,6 +96,15 @@
                     Automate the busy work in your day-to-day operations so people can get home on
                     time more often.
                 </p>
+            </svelte:fragment>
+            <svelte:fragment slot="cards">
+                <CartoonCard>
+                    <svelte:fragment slot="card_content">Developer Training Program & Dev Camp</svelte:fragment>
+                </CartoonCard>
+
+                <CartoonCard>
+                    <svelte:fragment slot="card_content">Technology Workshops</svelte:fragment>
+                </CartoonCard>
             </svelte:fragment>
         </ContentContainer>
     </div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,8 +1,8 @@
 <script>
     import BlueButton from '$lib/components/BlueButton.svelte';
     import Carousel from '$lib/components/Carousel.svelte';
-    import ContentContainer from '$lib/components/ContentContainer.svelte';
     import CartoonCard from '$lib/components/CartoonCard.svelte';
+    import ContentContainer from '$lib/components/ContentContainer.svelte';
 </script>
 
 <section
@@ -99,7 +99,9 @@
             </svelte:fragment>
             <svelte:fragment slot="cards">
                 <CartoonCard>
-                    <svelte:fragment slot="card_content">Developer Training Program & Dev Camp</svelte:fragment>
+                    <svelte:fragment slot="card_content"
+                        >Developer Training Program & Dev Camp</svelte:fragment
+                    >
                 </CartoonCard>
 
                 <CartoonCard>


### PR DESCRIPTION
This PR adds the four basic cards to their respective content containers ("For Students" and "For Organizations") in the "Why UP CSI?" section of the home page. This PR also modified certain CSS classes in the Cartoon Card component and added slots for its header and text. 