### PR TITLE
feat: add slots to button components

### DIFF
--- a/src/lib/components/BlackButton.svelte
+++ b/src/lib/components/BlackButton.svelte
@@ -1,3 +1,5 @@
-<button class="h-10 w-32 max-w-md rounded-full bg-black text-center font-inter text-csi-white"
-    >Get in Touch</button
+<button
+    class="rounded-full bg-black px-4 py-3 text-center font-inter text-csi-white dark:bg-csi-blue dark:text-black"
 >
+    <slot />
+</button>

--- a/src/lib/components/BlueButton.svelte
+++ b/src/lib/components/BlueButton.svelte
@@ -1,3 +1,5 @@
-<button class="h-10 w-32 max-w-md rounded-full bg-csi-blue text-center font-inter text-black"
-    >Get in Touch</button
+<button
+    class="rounded-full bg-csi-blue px-4 py-2 text-center font-inter text-black dark:bg-black dark:text-csi-white"
 >
+    <slot />
+</button>

--- a/src/lib/components/Contact.svelte
+++ b/src/lib/components/Contact.svelte
@@ -11,6 +11,6 @@
         <h1 class="mb-6 font-dm text-3xl font-light text-csi-black sm:text-5xl">
             Let's innovate together!
         </h1>
-        <BlackButton />
+        <BlackButton>Shoot us a message</BlackButton>
     </div>
 </section>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -107,5 +107,5 @@
 </section>
 <section class="prose max-w-full">
     <h1 class="font-dm">Connect with Us</h1>
-    <BlueButton />
+    <BlueButton>Shoot us a Message</BlueButton>
 </section>


### PR DESCRIPTION
This PR replaces the placeholder text in the `BlackButton` and `BlueButton` components with slots so their text can be changed for use in other components (i.e. contact component). Additionally, this PR changes some styles for flexibility and adds dark mode colors for both components such that dark mode `BlackButton` is colored to light mode `BlueButton` and vice versa. 

Edit: I didn't mean to attempt to deploy, not sure why it happened upon pull request. Also, to clarify, this component wasn't assigned to anyone but I'll be using this for my assigned components (contact and footer) so I decided to make a PR for this first since it might be used elsewhere. 