### PR TITLE
feat: add code for mission and vision statements

### DIFF
--- a/src/routes/about/Card.svelte
+++ b/src/routes/about/Card.svelte
@@ -1,13 +1,15 @@
 <script>
-    export let heading = '';
-    export let content = '';
     import src from '$lib/lino-sablay.svg';
 </script>
 
 <div class="flex w-full flex-col gap-2 md:w-1/4">
     <img {src} alt="Placeholder" class="w-full" />
     <div class="w-full">
-        <h1 class="text-2xl">{heading}</h1>
-        <p>{content}</p>
+        <h1 class="text-2xl">
+            <slot name="heading" />
+        </h1>
+        <p>
+            <slot name="content" />
+        </p>
     </div>
 </div>

--- a/src/routes/about/Card.svelte
+++ b/src/routes/about/Card.svelte
@@ -1,0 +1,13 @@
+<script>
+    export let heading = '';
+    export let content = '';
+    import src from '$lib/lino-sablay.svg';
+</script>
+
+<div class="flex w-full flex-col gap-2 md:w-1/4">
+    <img {src} alt="Placeholder" class="w-full" />
+    <div class="w-full">
+        <h1 class="text-2xl">{heading}</h1>
+        <p>{content}</p>
+    </div>
+</div>

--- a/src/routes/about/MissionVision.svelte
+++ b/src/routes/about/MissionVision.svelte
@@ -1,0 +1,42 @@
+<script>
+    import Card from './Card.svelte';
+</script>
+
+<div
+    class="flex flex-col gap-16 rounded-3xl bg-warm-white px-8 py-12 font-dm md:px-12 dark:bg-csi-black dark:text-csi-white"
+>
+    <div class="flex flex-col gap-8">
+        <div class="text-center text-2xl">Mission</div>
+        <div class="align-center flex flex-col justify-evenly gap-8 md:flex-row md:gap-4">
+            <Card
+                heading="Develop well-rounded DCS students"
+                content="with fundamental classroom learning through practical experience"
+            />
+            <Card
+                heading="Establish DCS as a center of student innovation"
+                content="and excellent in software engineering"
+            />
+            <Card
+                heading="Improve people's lives by producing works"
+                content="that advocate the right use of Computer Science and Software Engineering"
+            />
+        </div>
+    </div>
+    <div class="flex flex-col gap-8">
+        <div class="text-center text-2xl">Vision</div>
+        <div class="align-center flex flex-col justify-evenly gap-8 md:flex-row md:gap-4">
+            <Card
+                heading="Learn"
+                content="Create development camps wherein students can enrich their skills in Software Engineering."
+            />
+            <Card
+                heading="Create"
+                content="Have a diverse set of software projects to enhance the versatility of UP CSI."
+            />
+            <Card
+                heading="Innovate"
+                content="Showcase the quality projects produced by the Department of Computer Science (DCS) and the UP CSI and make them accessible to the public."
+            />
+        </div>
+    </div>
+</div>

--- a/src/routes/about/MissionVision.svelte
+++ b/src/routes/about/MissionVision.svelte
@@ -8,35 +8,47 @@
     <div class="flex flex-col gap-8">
         <div class="text-center text-2xl">Mission</div>
         <div class="align-center flex flex-col justify-evenly gap-8 md:flex-row md:gap-4">
-            <Card
-                heading="Develop well-rounded DCS students"
-                content="with fundamental classroom learning through practical experience"
-            />
-            <Card
-                heading="Establish DCS as a center of student innovation"
-                content="and excellent in software engineering"
-            />
-            <Card
-                heading="Improve people's lives by producing works"
-                content="that advocate the right use of Computer Science and Software Engineering"
-            />
+            <Card>
+                <span slot="heading">Develop well-rounded DCS students</span>
+                <span slot="content"
+                    >with fundamental classroom learning through practical experience</span
+                >
+            </Card>
+            <Card>
+                <span slot="heading">Establish DCS as a center of student innovation</span>
+                <span slot="content">and excellent in software engineering</span>
+            </Card>
+            <Card>
+                <span slot="heading">Improve people's lives by producing works</span>
+                <span slot="content"
+                    >that advocate the right use of Computer Science and Software Engineering</span
+                >
+            </Card>
         </div>
     </div>
     <div class="flex flex-col gap-8">
         <div class="text-center text-2xl">Vision</div>
         <div class="align-center flex flex-col justify-evenly gap-8 md:flex-row md:gap-4">
-            <Card
-                heading="Learn"
-                content="Create development camps wherein students can enrich their skills in Software Engineering."
-            />
-            <Card
-                heading="Create"
-                content="Have a diverse set of software projects to enhance the versatility of UP CSI."
-            />
-            <Card
-                heading="Innovate"
-                content="Showcase the quality projects produced by the Department of Computer Science (DCS) and the UP CSI and make them accessible to the public."
-            />
+            <Card>
+                <span slot="heading">Learn</span>
+                <span slot="content"
+                    >Create development camps wherein students can enrich their skills in Software
+                    Engineering.</span
+                >
+            </Card>
+            <Card>
+                <span slot="heading">Create</span>
+                <span slot="content"
+                    >Have a diverse set of software projects to enhance the versatility of UP CSI.</span
+                >
+            </Card>
+            <Card>
+                <span slot="heading">Innovate</span>
+                <span slot="content"
+                    >Showcase the quality projects produced by the Department of Computer Science
+                    (DCS) and the UP CSI and make them accessible to the public.</span
+                >
+            </Card>
         </div>
     </div>
 </div>


### PR DESCRIPTION
This PR adds an `about` folder inside the `routes` folder. Also, the code for Mission and Vision statements for the website is included inside the `about` folder since it is only used in the About page. Placeholder images were used in the meantime.