### PR TITLE
feat: add gray color and dark mode to page background

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -25,7 +25,7 @@
             content="We are a service-oriented organization aimed towards the enhancement of student learning from the University of the Philippines Diliman, Department of Computer Science by working with real-world projects."
         />
     </head>
-    <body data-sveltekit-preload-data="hover" class="bg-csi-white font-inter">
+    <body data-sveltekit-preload-data="hover" class="bg-csi-white font-inter dark:bg-csi-black">
         <div class="contents">%sveltekit.body%</div>
     </body>
 </html>

--- a/src/routes/Footer.svelte
+++ b/src/routes/Footer.svelte
@@ -21,7 +21,7 @@
             </p>
             <p><a href="https://github.com/up-csi">GitHub</a></p>
         </div>
-        <div>
+        <div class="text-gray">
             <p>Built with <a href="https://kit.svelte.dev/">SvelteKit</a>.</p>
             <!-- To remove after placeholder images are replaced -->
             <a href="https://storyset.com/web" class="text-sm underline"

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -21,6 +21,7 @@ export default {
             'blue-white': '#D7E6ED',
             blue: '#35ADBB',
             black: '#253242',
+            gray: '#A6A6A6',
         },
     },
     plugins: [forms, typo],


### PR DESCRIPTION
This PR adds the `gray` color (`#A6A6A6`) to the color themes and applies it to the "Built with SvelteKit" text in `Footer` (as well as the temporary attribution text). Also, this PR adds dark mode to the background of the page.