### PR TITLE
fix(HeroComponent.svelte): tweak layout for slightly more consistency with Figma design

### DIFF
--- a/src/lib/components/HeroComponent.svelte
+++ b/src/lib/components/HeroComponent.svelte
@@ -4,7 +4,7 @@
 
 <!--The current bg color is a placeholder, this should be a gradient-->
 <div
-    class="flex flex-col justify-center rounded-3xl bg-blue-white pt-24 md:flex-row dark:bg-csi-blue"
+    class="flex flex-col justify-center rounded-3xl bg-blue-white pt-36 md:flex-row dark:bg-csi-blue"
 >
     <div
         class="flex flex-col items-center pb-8 text-center md:w-5/12 md:items-start md:pl-20 md:text-left"

--- a/src/lib/components/HeroComponent.svelte
+++ b/src/lib/components/HeroComponent.svelte
@@ -2,15 +2,19 @@
     import src from '$lib/lino-sablay.svg';
 </script>
 
-<div class="flex flex-col flex-wrap items-center pt-24 sm:flex-row">
-    <div class="pb-8 text-center sm:w-2/4 sm:text-left">
-        <h1 class="sm:text-6x1 pb-2 font-dm text-5xl font-bold text-black">
-            Learn. Create. Innovate.
+<!--The current bg color is a placeholder, this should be a gradient-->
+<div class="bg-blue-white rounded-3xl flex flex-col justify-center pt-24 md:flex-row dark:bg-csi-blue">
+    <div class="pb-8 flex flex-col items-center text-center md:w-5/12 md:pl-20 md:items-start md:text-left">
+        <h1 class="md:text-6x1 pb-2 font-dm text-5xl font-bold text-black dark:text-csi-white">
+            Learn. Create.
         </h1>
-        <p class="pb-8 text-sm text-black">With UP Center for Student Innovations.</p>
-        <button class="rounded-full bg-black px-4 py-2 text-csi-white">Get in Touch</button>
+        <h1 class="md:text-6x1 pb-2 font-dm text-5xl font-bold text-black dark:text-csi-white">
+            Innovate.
+        </h1>
+        <p class="pb-8 text-sm text-black dark:text-csi-white">With UP Center for Student Innovations.</p>
+        <button class="rounded-full bg-black px-4 py-2 text-csi-white dark:bg-csi-blue dark:text-csi-white">Get in Touch</button>
     </div>
-    <div class="w-2/4">
-        <img {src} alt="Lino Sablay" />
+    <div class="flex flex-col items-center md:flex-row">
+        <img {src} alt="Lino Sablay" class="w-[550px]"/>
     </div>
 </div>

--- a/src/lib/components/HeroComponent.svelte
+++ b/src/lib/components/HeroComponent.svelte
@@ -3,18 +3,27 @@
 </script>
 
 <!--The current bg color is a placeholder, this should be a gradient-->
-<div class="bg-blue-white rounded-3xl flex flex-col justify-center pt-24 md:flex-row dark:bg-csi-blue">
-    <div class="pb-8 flex flex-col items-center text-center md:w-5/12 md:pl-20 md:items-start md:text-left">
+<div
+    class="flex flex-col justify-center rounded-3xl bg-blue-white pt-24 md:flex-row dark:bg-csi-blue"
+>
+    <div
+        class="flex flex-col items-center pb-8 text-center md:w-5/12 md:items-start md:pl-20 md:text-left"
+    >
         <h1 class="md:text-6x1 pb-2 font-dm text-5xl font-bold text-black dark:text-csi-white">
             Learn. Create.
         </h1>
         <h1 class="md:text-6x1 pb-2 font-dm text-5xl font-bold text-black dark:text-csi-white">
             Innovate.
         </h1>
-        <p class="pb-8 text-sm text-black dark:text-csi-white">With UP Center for Student Innovations.</p>
-        <button class="rounded-full bg-black px-4 py-2 text-csi-white dark:bg-csi-blue dark:text-csi-white">Get in Touch</button>
+        <p class="pb-8 text-sm text-black dark:text-csi-white">
+            With UP Center for Student Innovations.
+        </p>
+        <button
+            class="rounded-full bg-black px-4 py-2 text-csi-white dark:bg-csi-blue dark:text-csi-white"
+            >Get in Touch</button
+        >
     </div>
     <div class="flex flex-col items-center md:flex-row">
-        <img {src} alt="Lino Sablay" class="w-[550px]"/>
+        <img {src} alt="Lino Sablay" class="w-[550px]" />
     </div>
 </div>


### PR DESCRIPTION
This PR makes the sizing of the images and text layout a little more consistent with the Figma design. It also adds some dark mode styles (though doesn't use prose or prose-invert).

As a note for the next changes to be made for this component, the background color needs to be a gradient, and I think the image has to use some sort of (maybe?) absolute positioning to get the effect of Lino perching on the bottom of the Hero component.