### PR TITLE
feat: add basic prose-invert fix various colors

### DIFF
--- a/src/lib/components/Button.svelte
+++ b/src/lib/components/Button.svelte
@@ -1,5 +1,5 @@
 <button
-    class="rounded-full px-4 py-3 text-center font-inter bg-black text-csi-white dark:bg-csi-blue dark:text-csi-black"
+    class="rounded-full bg-black px-4 py-3 text-center font-inter text-csi-white dark:bg-csi-blue dark:text-csi-black"
 >
     <slot />
 </button>

--- a/src/lib/components/Button.svelte
+++ b/src/lib/components/Button.svelte
@@ -1,5 +1,5 @@
 <button
-    class="rounded-full bg-black px-4 py-3 text-center font-inter text-csi-white dark:bg-csi-blue dark:text-black"
+    class="rounded-full px-4 py-3 text-center font-inter bg-black text-csi-white dark:bg-csi-blue dark:text-csi-black"
 >
     <slot />
 </button>

--- a/src/lib/components/HeroComponent.svelte
+++ b/src/lib/components/HeroComponent.svelte
@@ -2,9 +2,8 @@
     import src from '$lib/lino-sablay.svg';
 </script>
 
-<!--The current bg color is a placeholder, this should be a gradient-->
 <div
-    class="flex flex-col justify-center rounded-3xl bg-blue-white pt-36 md:flex-row dark:bg-csi-blue"
+    class="flex flex-col justify-center rounded-3xl bg-gradient-to-b from-csi-blue/25 to-blue-white/25 pt-36 md:flex-row dark:from-csi-blue/50 dark:to-blue-neutral/25"
 >
     <div
         class="flex flex-col items-center pb-8 text-center md:w-5/12 md:items-start md:pl-20 md:text-left"

--- a/src/lib/components/HeroComponent.svelte
+++ b/src/lib/components/HeroComponent.svelte
@@ -1,5 +1,6 @@
 <script>
     import src from '$lib/lino-sablay.svg';
+    import Button from './Button.svelte';
 </script>
 
 <div
@@ -17,10 +18,7 @@
         <p class="pb-8 text-sm text-black dark:text-csi-white">
             With UP Center for Student Innovations.
         </p>
-        <button
-            class="rounded-full bg-black px-4 py-2 text-csi-white dark:bg-csi-blue dark:text-csi-white"
-            >Get in Touch</button
-        >
+        <Button>Get in Touch</Button>
     </div>
     <div class="flex flex-col items-center md:flex-row">
         <img {src} alt="Lino Sablay" class="w-[550px]" />

--- a/src/lib/components/HeroComponent.svelte
+++ b/src/lib/components/HeroComponent.svelte
@@ -1,6 +1,6 @@
 <script>
-    import src from '$lib/lino-sablay.svg';
     import Button from './Button.svelte';
+    import src from '$lib/lino-sablay.svg';
 </script>
 
 <div

--- a/src/lib/components/carousel/Card.svelte
+++ b/src/lib/components/carousel/Card.svelte
@@ -3,7 +3,7 @@
 </script>
 
 <!-- Carousel Card with filler content -->
-<div class="w-48 snap-center rounded-full bg-csi-blue text-csi-black p-4 text-center font-inter">
+<div class="w-48 snap-center rounded-full bg-csi-blue p-4 text-center font-inter text-csi-black">
     <!-- Sample Text -->
     <slot class="m-0">{name}</slot>
     <!-- Sample Logo -->

--- a/src/lib/components/carousel/Card.svelte
+++ b/src/lib/components/carousel/Card.svelte
@@ -3,7 +3,7 @@
 </script>
 
 <!-- Carousel Card with filler content -->
-<div class="w-48 snap-center rounded-full bg-blue p-4 text-center font-inter">
+<div class="w-48 snap-center rounded-full bg-csi-blue text-csi-black p-4 text-center font-inter">
     <!-- Sample Text -->
     <slot class="m-0">{name}</slot>
     <!-- Sample Logo -->

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -13,7 +13,7 @@
     id="about"
     class="flex items-center bg-lino bg-contain bg-center bg-no-repeat bg-origin-content sm:h-[40vh] sm:bg-right lg:h-[60vh]"
 >
-    <div class="prose">
+    <div class="prose dark:prose-invert">
         <h1 class="font-dm">Learn. Create. Innovate.</h1>
         <p>
             We are a service-oriented organization aimed towards the enhancement of student learning
@@ -22,7 +22,7 @@
         </p>
     </div>
 </section>
-<section class="prose max-w-full">
+<section class="prose dark:prose-invert max-w-full">
     <h2 class="font-dm">Our Mission</h2>
     <ul>
         <li>
@@ -36,7 +36,7 @@
         </li>
     </ul>
 </section>
-<section class="prose max-w-full">
+<section class="prose dark:prose-invert max-w-full">
     <h2 class="font-dm">Our Vision</h2>
     <ul>
         <li>
@@ -52,7 +52,7 @@
         </li>
     </ul>
 </section>
-<section class="prose max-w-full">
+<section class="prose dark:prose-invert max-w-full">
     <h2 class="font-dm">What We Do</h2>
     <p>
         Our mission is to provide opportunities for students to enhance their software engineering
@@ -65,7 +65,7 @@
         <li>Providing solutions to <em>your</em> problems.</li>
     </ul>
 </section>
-<section class="prose max-w-full">
+<section class="prose dark:prose-invert max-w-full">
     <h1 class="font-dm">Why UP CSI?</h1>
     <div class="space-y-4">
         <ContentContainer>
@@ -106,10 +106,10 @@
         </ContentContainer>
     </div>
 </section>
-<section class="prose max-w-full">
+<section class="prose dark:prose-invert max-w-full">
     <h3 class="text-center font-dm">We've worked with</h3>
     <Carousel />
 </section>
-<section class="prose max-w-full">
+<section class="prose dark:prose-invert max-w-full">
     <Contact />
 </section>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -22,7 +22,7 @@
         </p>
     </div>
 </section>
-<section class="prose dark:prose-invert max-w-full">
+<section class="prose max-w-full dark:prose-invert">
     <h2 class="font-dm">Our Mission</h2>
     <ul>
         <li>
@@ -36,7 +36,7 @@
         </li>
     </ul>
 </section>
-<section class="prose dark:prose-invert max-w-full">
+<section class="prose max-w-full dark:prose-invert">
     <h2 class="font-dm">Our Vision</h2>
     <ul>
         <li>
@@ -52,7 +52,7 @@
         </li>
     </ul>
 </section>
-<section class="prose dark:prose-invert max-w-full">
+<section class="prose max-w-full dark:prose-invert">
     <h2 class="font-dm">What We Do</h2>
     <p>
         Our mission is to provide opportunities for students to enhance their software engineering
@@ -65,7 +65,7 @@
         <li>Providing solutions to <em>your</em> problems.</li>
     </ul>
 </section>
-<section class="prose dark:prose-invert max-w-full">
+<section class="prose max-w-full dark:prose-invert">
     <h1 class="font-dm">Why UP CSI?</h1>
     <div class="space-y-4">
         <ContentContainer>
@@ -106,10 +106,10 @@
         </ContentContainer>
     </div>
 </section>
-<section class="prose dark:prose-invert max-w-full">
+<section class="prose max-w-full dark:prose-invert">
     <h3 class="text-center font-dm">We've worked with</h3>
     <Carousel />
 </section>
-<section class="prose dark:prose-invert max-w-full">
+<section class="prose max-w-full dark:prose-invert">
     <Contact />
 </section>

--- a/src/routes/events/+page.svelte
+++ b/src/routes/events/+page.svelte
@@ -1,3 +1,3 @@
-<article class="prose">
+<article class="prose dark:prose-invert">
     <h1>Events</h1>
 </article>

--- a/src/routes/news/+page.svelte
+++ b/src/routes/news/+page.svelte
@@ -1,3 +1,3 @@
-<article class="prose">
+<article class="prose dark:prose-invert">
     <h1>News</h1>
 </article>

--- a/src/routes/partners/+page.svelte
+++ b/src/routes/partners/+page.svelte
@@ -1,3 +1,3 @@
-<article class="prose">
+<article class="prose dark:prose-invert">
     <h1>Partnerships</h1>
 </article>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -7,7 +7,6 @@ export default {
     darkMode: 'selector',
     content: ['./src/**/*.{css,html,js,svelte,ts}'],
     theme: {
-        backgroundImage: { lino: 'url("$lib/lino-hero.svg")' },
         fontFamily: {
             dm: ['DMSans', ...defaultTheme.fontFamily.sans],
             inter: ['Inter', ...defaultTheme.fontFamily.sans],
@@ -32,6 +31,7 @@ export default {
             },
             'warm-white': '#E0E1E0',
             'blue-white': '#D7E6ED',
+            'blue-neutral': '#32718E',
             blue: '#35ADBB',
             black: '#253242',
             gray: '#A6A6A6',
@@ -49,7 +49,10 @@ export default {
                         '--tw-prose-invert-bullets': theme('colors.csi-white'),
                     }
                 }
-            })
+            }),
+            backgroundImage: {
+                lino: 'url("$lib/lino-hero.svg")',
+            },
         }
     },
     plugins: [forms, typo],

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -37,6 +37,20 @@ export default {
             gray: '#A6A6A6',
             white: '#FFFFFF',
         },
+        extend: {
+            typography: ({ theme }) => ({
+                DEFAULT: {
+                    css: {
+                        '--tw-prose-body': theme('colors.csi-black'),
+                        '--tw-prose-headings': theme('colors.csi-black'),
+                        '--tw-prose-bullets': theme('colors.csi-black'),
+                        '--tw-prose-invert-body': theme('colors.csi-white'),
+                        '--tw-prose-invert-headings': theme('colors.csi-white'),
+                        '--tw-prose-invert-bullets': theme('colors.csi-white'),
+                    }
+                }
+            })
+        }
     },
     plugins: [forms, typo],
 } satisfies Config;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -47,13 +47,13 @@ export default {
                         '--tw-prose-invert-body': theme('colors.csi-white'),
                         '--tw-prose-invert-headings': theme('colors.csi-white'),
                         '--tw-prose-invert-bullets': theme('colors.csi-white'),
-                    }
-                }
+                    },
+                },
             }),
             backgroundImage: {
                 lino: 'url("$lib/lino-hero.svg")',
             },
-        }
+        },
     },
     plugins: [forms, typo],
 } satisfies Config;


### PR DESCRIPTION
This PR adds `prose-invert` and configures typography themes to provide (very) basic dark mode coloring to various pieces of text that had the `prose` class. Note that I only specified typography prose colors for body text, heading text, and bullet points as this seems to be all that is needed at the moment. In the future, other contributors will likely have to add or change these color themes depending on what the original design needs.

Additionally, the color gradient was implemented into `HeroComponent.svelte`. For this, I had to change the `tailwind.config.ts` such that `backgroundImage` theme extends instead, as replacing tailwind's default `backgroundImage` theme means removing its ability to generate gradients (tailwind background gradients are defined under `backgroundImage`). 

Besides those, this PR just tweaks the colors and styles of a few components for added consistency with the design and uniformity with other components. 