### PR TITLE
fix: fix lino and navbar positioning

### DIFF
--- a/src/lib/components/HeroComponent.svelte
+++ b/src/lib/components/HeroComponent.svelte
@@ -4,22 +4,20 @@
 </script>
 
 <div
-    class="h-auto lg:h-136 flex flex-col lg:flex-row justify-between items-center rounded-3xl bg-gradient-to-b from-csi-blue/25 to-blue-white/25 dark:from-csi-blue/50 dark:to-blue-neutral/25"
+    class="flex h-auto flex-col items-center justify-between rounded-3xl bg-gradient-to-b from-csi-blue/25 to-blue-white/25 lg:h-136 lg:flex-row dark:from-csi-blue/50 dark:to-blue-neutral/25"
 >
     <div
-        class="mb-12 mt-24 mx-5 lg:mr-0 lg:ml-20 xl:ml-40 gap-12 flex flex-col items-center lg:items-start text-center lg:text-left"
+        class="mx-5 mb-12 mt-24 flex flex-col items-center gap-12 text-center lg:ml-20 lg:mr-0 lg:items-start lg:text-left xl:ml-40"
     >
-        <div class="gap-3 flex flex-col text-csi-black dark:text-csi-white">
-            <h1 class="font-dm text-5xl sm:text-6xl font-bold sm:w-104 leading-tight">
+        <div class="flex flex-col gap-3 text-csi-black dark:text-csi-white">
+            <h1 class="font-dm text-5xl font-bold leading-tight sm:w-104 sm:text-6xl">
                 Learn. Create. Innovate.
             </h1>
-            <p class="text-sm">
-                With UP Center for Student Innovations.
-            </p>
+            <p class="text-sm">With UP Center for Student Innovations.</p>
         </div>
         <Button>Get in Touch</Button>
     </div>
-    <div class="h-full lg:mr-6 flex flex-col items-center justify-end">
-        <img {src} alt="Lino Sablay" class="w-156 relative top-4 sm:top-6" />
+    <div class="flex h-full flex-col items-center justify-end lg:mr-6">
+        <img {src} alt="Lino Sablay" class="relative top-4 w-156 sm:top-6" />
     </div>
 </div>

--- a/src/lib/components/HeroComponent.svelte
+++ b/src/lib/components/HeroComponent.svelte
@@ -4,23 +4,22 @@
 </script>
 
 <div
-    class="flex flex-col justify-center rounded-3xl bg-gradient-to-b from-csi-blue/25 to-blue-white/25 pt-36 md:flex-row dark:from-csi-blue/50 dark:to-blue-neutral/25"
+    class="h-auto lg:h-136 flex flex-col lg:flex-row justify-between items-center rounded-3xl bg-gradient-to-b from-csi-blue/25 to-blue-white/25 dark:from-csi-blue/50 dark:to-blue-neutral/25"
 >
     <div
-        class="flex flex-col items-center pb-8 text-center md:w-5/12 md:items-start md:pl-20 md:text-left"
+        class="mb-12 mt-24 mx-5 lg:mr-0 lg:ml-20 xl:ml-40 gap-12 flex flex-col items-center lg:items-start text-center lg:text-left"
     >
-        <h1 class="md:text-6x1 pb-2 font-dm text-5xl font-bold text-black dark:text-csi-white">
-            Learn. Create.
-        </h1>
-        <h1 class="md:text-6x1 pb-2 font-dm text-5xl font-bold text-black dark:text-csi-white">
-            Innovate.
-        </h1>
-        <p class="pb-8 text-sm text-black dark:text-csi-white">
-            With UP Center for Student Innovations.
-        </p>
+        <div class="gap-3 flex flex-col text-csi-black dark:text-csi-white">
+            <h1 class="font-dm text-5xl sm:text-6xl font-bold sm:w-104 leading-tight">
+                Learn. Create. Innovate.
+            </h1>
+            <p class="text-sm">
+                With UP Center for Student Innovations.
+            </p>
+        </div>
         <Button>Get in Touch</Button>
     </div>
-    <div class="flex flex-col items-center md:flex-row">
-        <img {src} alt="Lino Sablay" class="w-[550px]" />
+    <div class="h-full lg:mr-6 flex flex-col items-center justify-end">
+        <img {src} alt="Lino Sablay" class="w-156 relative top-4 sm:top-6" />
     </div>
 </div>

--- a/src/lib/components/HeroComponent.svelte
+++ b/src/lib/components/HeroComponent.svelte
@@ -4,13 +4,13 @@
 </script>
 
 <div
-    class="flex h-auto flex-col items-center justify-between rounded-3xl bg-gradient-to-b from-csi-blue/25 to-blue-white/25 lg:h-136 lg:flex-row dark:from-csi-blue/50 dark:to-blue-neutral/25"
+    class="flex h-auto flex-col items-center justify-between rounded-3xl bg-gradient-to-b from-csi-blue/25 to-blue-white/25 lg:h-[34rem] lg:flex-row dark:from-csi-blue/50 dark:to-blue-neutral/25"
 >
     <div
         class="mx-5 mb-12 mt-24 flex flex-col items-center gap-12 text-center lg:ml-20 lg:mr-0 lg:items-start lg:text-left xl:ml-40"
     >
         <div class="flex flex-col gap-3 text-csi-black dark:text-csi-white">
-            <h1 class="font-dm text-5xl font-bold leading-tight sm:w-104 sm:text-6xl">
+            <h1 class="font-dm text-5xl font-bold leading-tight sm:w-[26rem] sm:text-6xl">
                 Learn. Create. Innovate.
             </h1>
             <p class="text-sm">With UP Center for Student Innovations.</p>
@@ -18,6 +18,6 @@
         <Button>Get in Touch</Button>
     </div>
     <div class="flex h-full flex-col items-center justify-end lg:mr-6">
-        <img {src} alt="Lino Sablay" class="relative top-4 w-156 sm:top-6" />
+        <img {src} alt="Lino Sablay" class="relative top-4 w-[39rem] sm:top-6" />
     </div>
 </div>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -10,10 +10,10 @@
     $: if (browser) document.documentElement.classList.toggle('dark', $theme);
 </script>
 
-<header class="sticky top-0 lg:top-12">
+<header class="sticky lg:fixed top-0 lg:top-10 lg:inset-x-0 z-50">
     <NavBar />
 </header>
-<main class="m-4 space-y-16 sm:m-8 xl:m-32 xl:my-16">
+<main class="m-4 space-y-16 sm:mt-5 sm:m-8 xl:mx-32 xl:mb-16">
     <slot />
 </main>
 <Footer />

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -10,10 +10,10 @@
     $: if (browser) document.documentElement.classList.toggle('dark', $theme);
 </script>
 
-<header class="sticky lg:fixed top-0 lg:top-10 lg:inset-x-0 z-50">
+<header class="sticky top-0 z-50 lg:fixed lg:inset-x-0 lg:top-10">
     <NavBar />
 </header>
-<main class="m-4 space-y-16 sm:mt-5 sm:m-8 xl:mx-32 xl:mb-16">
+<main class="m-4 space-y-16 sm:m-8 sm:mt-5 xl:mx-32 xl:mb-16">
     <slot />
 </main>
 <Footer />

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -13,7 +13,7 @@
 <header class="sticky top-0 z-50 lg:inset-x-0 lg:top-12">
     <NavBar />
 </header>
-<main class="m-4 space-y-16 sm:m-8 sm:mt-5 xl:mx-32 lg:my-16">
+<main class="m-4 space-y-16 sm:m-8 sm:mt-5 lg:my-16 xl:mx-32">
     <!-- m-4 space-y-16 sm:m-8 xl:m-32 xl:my-16 -->
     <slot />
 </main>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -10,10 +10,11 @@
     $: if (browser) document.documentElement.classList.toggle('dark', $theme);
 </script>
 
-<header class="sticky top-0 z-50 lg:fixed lg:inset-x-0 lg:top-10">
+<header class="sticky top-0 z-50 lg:inset-x-0 lg:top-12">
     <NavBar />
 </header>
-<main class="m-4 space-y-16 sm:m-8 sm:mt-5 xl:mx-32 xl:mb-16">
+<main class="m-4 space-y-16 sm:m-8 sm:mt-5 xl:mx-32 lg:my-16">
+    <!-- m-4 space-y-16 sm:m-8 xl:m-32 xl:my-16 -->
     <slot />
 </main>
 <Footer />

--- a/src/routes/NavBar.svelte
+++ b/src/routes/NavBar.svelte
@@ -10,7 +10,7 @@
 
 <nav class="flex items-center justify-center">
     <ul
-        class="flex w-full flex-row items-center justify-between gap-4 bg-csi-neutral-50 p-1 text-csi-black lg:w-fit lg:rounded-xl dark:bg-csi-neutral-950 dark:text-csi-white"
+        class="flex w-full flex-row items-center justify-between gap-4 bg-csi-neutral-50 p-1 text-csi-black shadow-md lg:w-fit lg:rounded-xl dark:bg-csi-neutral-950 dark:text-csi-white"
     >
         <li class="mx-6 sm:mx-10 lg:ml-8 lg:mr-4">
             <img src={upcsi} alt="UP CSI Logo" class="h-8 object-contain" />

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -59,7 +59,7 @@ export default {
             width: {
                 '104': '26rem',
                 '156': '39rem',
-            }
+            },
         },
     },
     plugins: [forms, typo],

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -53,13 +53,6 @@ export default {
             backgroundImage: {
                 lino: 'url("$lib/lino-hero.svg")',
             },
-            height: {
-                '136': '34rem',
-            },
-            width: {
-                '104': '26rem',
-                '156': '39rem',
-            },
         },
     },
     plugins: [forms, typo],

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -53,6 +53,13 @@ export default {
             backgroundImage: {
                 lino: 'url("$lib/lino-hero.svg")',
             },
+            height: {
+                '136': '34rem',
+            },
+            width: {
+                '104': '26rem',
+                '156': '39rem',
+            }
         },
     },
     plugins: [forms, typo],


### PR DESCRIPTION
This PR adjusts various styles in `HeroComponent.svelte` and fixes the position of Lino in the Hero component so that it looks more like Lino is perched on the border of the component for added consistency with the design. Also, the navbar was changed to have `position: fixed` when viewed on large screens so that the navbar does not affect normal document flow and matches the design (where the navbar starts above the hero component). 