### PR TITLE
feat: add featured event card in events route

### DIFF
--- a/src/routes/events/FeaturedEvent.svelte
+++ b/src/routes/events/FeaturedEvent.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+    import Button from '$lib/components/Button.svelte';
+
+    export let tags: string[] = [];
+    export let schedule: string[] = [];
+</script>
+
+<!-- Featured Card Event
+tags and schedule - pass as props
+image, event name, description - pass as slot -->
+<div
+    class="flex w-full flex-col items-center justify-center gap-6 rounded-3xl bg-csi-white p-4 text-center md:flex-row md:justify-normal md:gap-8 md:text-left"
+>
+    <div class="flex w-full flex-col border-b-2 md:w-1/3 md:flex-row md:border-b-0">
+        <slot name="image" />
+    </div>
+
+    <div class="flex w-2/3 flex-col items-center gap-6 md:items-start">
+        <!-- Tags -->
+        <div class="flex gap-4">
+            {#each tags as tag}
+                <Button>
+                    {tag}
+                </Button>
+            {/each}
+        </div>
+
+        <!-- Event Name -->
+        <h2 class="font-inter text-4xl font-bold"><slot name="name" /></h2>
+
+        <!-- Schedule -->
+        <div>
+            {#each schedule as sched}
+                <p>{sched}</p>
+            {/each}
+        </div>
+
+        <!-- Description -->
+        <p><slot name="description" /></p>
+
+        <!-- Call to Action (replace button to anchor tag when there is a valid href) -->
+        <div class="flex gap-6">
+            <button class="bg-csi-black p-3 text-center text-csi-white">More Info</button>
+            <button class="bg-csi-black p-3 text-center text-csi-white">Register</button>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
I added the featured event card that is found in the events route of the website. I've used slots to pass the image, event name, and the description to the component. On the other hand, I've used props (array of strings) to pass the tags and schedules for the card.