### PR TITLE
fix: create `404.html` page on build for github pages

### DIFF
--- a/svelte.config.js
+++ b/svelte.config.js
@@ -5,5 +5,9 @@ import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 export default {
     extensions: ['.svelte', '.md'],
     preprocess: vitePreprocess(),
-    kit: { adapter: adapter() },
+    kit: {
+        adapter: adapter({
+            fallback: '404.html',
+        }),
+    },
 };


### PR DESCRIPTION
At the moment, the custom 404 error page made in #60 will not appear if you attempt to go to a non-existent page (i.e. [https://up-csi.org/not-a-real-url](https://up-csi.org/not-a-real-url)). This is because the 404 error page displayed by github pages depends on a `404.html` which wasn't being generated during building. This PR attempts to fix this issue by adding `fallback: '404.html'` in `svelte.config.js` as suggested in the [SvelteKit documentation for github pages](https://kit.svelte.dev/docs/adapter-static#github-pages).

EDIT: fixed link formatting