### PR TITLE
fix: remove Carousel section remnants

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -54,8 +54,5 @@
     </div>
 </section>
 <section class="prose max-w-full dark:prose-invert">
-    <h3 class="text-center font-dm">We've worked with</h3>
-</section>
-<section class="prose max-w-full dark:prose-invert">
     <Contact />
 </section>


### PR DESCRIPTION
This PR removes some leftover remnants of the Carousel section on the home page for the time being, as per #52.