### PR TITLE
feat(homepage): add scroll functionality to 'Get in Touch' buttons

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html class="scroll-smooth" lang="en">
     <head>
         <title>UP CSI - Center for Student Innovations</title>
         <link rel="icon" href="%sveltekit.assets%/favicon.png" />

--- a/src/lib/components/Button.svelte
+++ b/src/lib/components/Button.svelte
@@ -1,4 +1,5 @@
 <button
+    on:click
     class="rounded-full bg-black px-4 py-3 text-center font-inter text-csi-white dark:bg-csi-blue dark:text-csi-black"
 >
     <slot />

--- a/src/lib/components/HeroComponent.svelte
+++ b/src/lib/components/HeroComponent.svelte
@@ -1,5 +1,6 @@
 <script>
     import Button from './Button.svelte';
+    import { scrollToFooter } from '$lib/utils/scrollUtils.js';
     import src from '$lib/lino-sablay.svg';
 </script>
 
@@ -15,7 +16,7 @@
             </h1>
             <p class="text-sm">With UP Center for Student Innovations.</p>
         </div>
-        <Button>Get in Touch</Button>
+        <Button on:click={scrollToFooter}>Get in Touch</Button>
     </div>
     <div class="flex h-full flex-col items-center justify-end lg:mr-6">
         <img {src} alt="Lino Sablay" class="relative top-4 w-[39rem] sm:top-6" />

--- a/src/lib/utils/scrollUtils.js
+++ b/src/lib/utils/scrollUtils.js
@@ -1,0 +1,6 @@
+export function scrollToFooter() {
+    const footer = document.querySelector('footer');
+    if (footer) {
+        footer.scrollIntoView({ behavior: 'smooth' });
+    }
+}

--- a/src/routes/NavBar.svelte
+++ b/src/routes/NavBar.svelte
@@ -2,6 +2,7 @@
     import darkmode from '$lib/icons/darkmode.svg';
     import { get } from '$lib/stores/color-scheme';
     import lightmode from '$lib/icons/lightmode.svg';
+    import { scrollToFooter } from '$lib/utils/scrollUtils.js';
     import upcsi from '$lib/icons/upcsi.svg';
 
     let mobileMenu = false;
@@ -41,7 +42,10 @@
             >
         </li>
         <li class="hidden lg:block">
-            <button class="rounded-lg bg-csi-blue px-5 py-2 text-csi-black">Get in Touch</button>
+            <button
+                on:click={scrollToFooter}
+                class="rounded-lg bg-csi-blue px-5 py-2 text-csi-black">Get in Touch</button
+            >
         </li>
         <li class="mx-6 my-2 flex flex-row items-center sm:mx-10 lg:hidden">
             <button class="flex items-center justify-center" on:click={theme.toggle}


### PR DESCRIPTION
Add scrolling behavior for contact-related buttons on the homepage and the 'Get in Touch' button in the navigation bar. These buttons now scroll down to the footer containing UP CSI's contact information.