### PR TITLE
feat(homepage): add email functionality to contact buttons

### DIFF
--- a/src/lib/components/ButtonMailTo.svelte
+++ b/src/lib/components/ButtonMailTo.svelte
@@ -1,0 +1,6 @@
+<a
+    href="mailto:lino@up-csi.org"
+    class="rounded-full bg-black px-4 py-3 text-center font-inter text-csi-white no-underline dark:bg-csi-blue dark:text-csi-black"
+>
+    <slot />
+</a>

--- a/src/lib/components/Contact.svelte
+++ b/src/lib/components/Contact.svelte
@@ -1,5 +1,5 @@
 <script>
-    import Button from '$lib/components/Button.svelte';
+    import ButtonMailTo from '$lib/components/ButtonMailTo.svelte';
     import src from '$lib/lino-hero.svg';
 </script>
 
@@ -13,6 +13,6 @@
         >
             Let's innovate together!
         </h1>
-        <Button>Shoot us a message</Button>
+        <ButtonMailTo>Shoot us a message</ButtonMailTo>
     </div>
 </section>

--- a/src/lib/components/HeroComponent.svelte
+++ b/src/lib/components/HeroComponent.svelte
@@ -1,5 +1,5 @@
 <script>
-    import Button from './Button.svelte';
+    import ButtonMailTo from '$lib/components/ButtonMailTo.svelte';
     import src from '$lib/lino-sablay.svg';
 </script>
 
@@ -15,7 +15,7 @@
             </h1>
             <p class="text-sm">With UP Center for Student Innovations.</p>
         </div>
-        <Button>Get in Touch</Button>
+        <ButtonMailTo>Get in Touch</ButtonMailTo>
     </div>
     <div class="flex h-full flex-col items-center justify-end lg:mr-6">
         <img {src} alt="Lino Sablay" class="relative top-4 w-[39rem] sm:top-6" />


### PR DESCRIPTION
Clicking 'Get In Touch' and 'Shoot Us a Message' buttons on the homepage now opens the default mail client via mailto links.