### PR TITLE
fix(TeamCard): fix issue with member images not expanding correctly

### DIFF
--- a/src/routes/people/TeamCard.svelte
+++ b/src/routes/people/TeamCard.svelte
@@ -20,7 +20,7 @@
         {alt}
         height="300px"
         loading="lazy"
-        class="col-start-1 row-start-1 m-0 h-56 rounded-2xl object-cover md:h-auto"
+        class="col-start-1 row-start-1 m-0 h-56 w-full rounded-2xl object-cover md:h-auto"
     />
     {#if isOverlayVisible}
         <div

--- a/src/routes/people/TeamCard.svelte
+++ b/src/routes/people/TeamCard.svelte
@@ -20,7 +20,7 @@
         {alt}
         height="300px"
         loading="lazy"
-        class="col-start-1 row-start-1 m-0 h-56 w-full rounded-2xl object-cover md:h-auto"
+        class="col-start-1 row-start-1 m-0 h-56 w-full rounded-2xl object-cover md:h-full"
     />
     {#if isOverlayVisible}
         <div


### PR DESCRIPTION
This PR adds a missing `w-full` that's supposed to expand the member images on the People page correctly. In the future, we might want to consider using [`enhanced:img`](https://kit.svelte.dev/docs/images#sveltejs-enhanced-img) instead, but this should do for an urgent change.