### PR TITLE
feat(Accordion): add dropdown component to Projects page

### DIFF
--- a/src/lib/components/Accordion.svelte
+++ b/src/lib/components/Accordion.svelte
@@ -18,13 +18,15 @@
     const { children, title }: Props = $props();
 </script>
 
-<div class="w-full rounded-2xl shadow-lg">
+<div class="w-full rounded-2xl bg-csi-neutral-50 shadow-lg dark:bg-csi-neutral-900">
     <button
-        class="flex w-full rounded-2xl bg-csi-neutral-50 px-5 py-4 aria-expanded:bg-csi-neutral-100"
+        class="flex w-full rounded-2xl bg-csi-neutral-50 px-5 py-4 aria-expanded:bg-csi-neutral-100 dark:bg-csi-neutral-900 aria-expanded:dark:bg-csi-neutral-700"
         onclick={toggle}
         aria-expanded={open}
     >
-        <span class="grow text-left font-inter text-lg font-bold">{title}</span>
+        <span class="grow text-left font-inter text-lg font-bold text-csi-black dark:text-csi-white"
+            >{title}</span
+        >
         <span class="grow-0">
             <Icon
                 icon={ChevronDown}
@@ -34,7 +36,10 @@
         </span>
     </button>
     {#if open}
-        <div class="flex w-full items-center px-5 py-4" transition:slide>
+        <div
+            class="flex w-full items-center px-5 py-4 text-csi-black dark:text-csi-white"
+            transition:slide
+        >
             {@render children?.()}
         </div>
     {/if}

--- a/src/lib/components/Accordion.svelte
+++ b/src/lib/components/Accordion.svelte
@@ -1,0 +1,41 @@
+<script lang="ts">
+    import ChevronDown from '@iconify/icons-heroicons/chevron-down';
+    import Icon from '@iconify/svelte';
+    import type { Snippet } from 'svelte';
+    import { slide } from 'svelte/transition';
+
+    interface Props {
+        title: string;
+        children?: Snippet;
+    }
+
+    let open: boolean = $state(false);
+
+    function toggle() {
+        open = !open;
+    }
+
+    const { children, title }: Props = $props();
+</script>
+
+<div class="w-full rounded-2xl shadow-lg">
+    <button
+        class="flex w-full rounded-2xl bg-csi-neutral-50 px-5 py-4 aria-expanded:bg-csi-neutral-100"
+        onclick={toggle}
+        aria-expanded={open}
+    >
+        <span class="grow text-left font-inter text-lg font-bold">{title}</span>
+        <span class="grow-0">
+            <Icon
+                icon={ChevronDown}
+                class="size-5 text-csi-black transition-transform aria-expanded:rotate-90 dark:text-csi-white"
+                aria-expanded={open}
+            />
+        </span>
+    </button>
+    {#if open}
+        <div class="flex w-full items-center px-5 py-4" transition:slide>
+            {@render children?.()}
+        </div>
+    {/if}
+</div>

--- a/src/lib/components/Accordion.svelte
+++ b/src/lib/components/Accordion.svelte
@@ -20,7 +20,7 @@
 
 <div class="w-full rounded-2xl bg-csi-neutral-50 shadow-lg dark:bg-csi-neutral-900">
     <button
-        class="flex w-full rounded-2xl bg-csi-neutral-50 px-5 py-4 aria-expanded:bg-csi-neutral-100 dark:bg-csi-neutral-900 aria-expanded:dark:bg-csi-neutral-700"
+        class="flex w-full items-center rounded-2xl bg-csi-neutral-50 px-5 py-4 aria-expanded:bg-csi-neutral-100 dark:bg-csi-neutral-900 aria-expanded:dark:bg-csi-neutral-700"
         onclick={toggle}
         aria-expanded={open}
     >

--- a/src/routes/projects/+page.svelte
+++ b/src/routes/projects/+page.svelte
@@ -1,4 +1,5 @@
 <script>
+    import Accordion from '$lib/components/Accordion.svelte';
     import FilterPagePanel from '$lib/components/FilterPagePanel.svelte';
     import GeneralInfo from './GeneralInfo.svelte';
     import SocialMediaPanel from '$lib/components/SocialMediaPanel.svelte';
@@ -16,3 +17,10 @@
         <SocialMediaPanel />
     </div>
 </article>
+
+<section>
+    <h1 class="mb-4 w-2/5 text-3xl text-csi-black md:text-4xl dark:text-csi-white">FAQs</h1>
+    <Accordion title="Lorem ipsum dolor sit amet?">
+        <span> Lorem ipsum dolor sit amet adipiscing elit consectitur </span>
+    </Accordion>
+</section>

--- a/src/routes/projects/+page.svelte
+++ b/src/routes/projects/+page.svelte
@@ -20,7 +20,9 @@
 
 <section>
     <h1 class="mb-4 w-2/5 text-3xl text-csi-black md:text-4xl dark:text-csi-white">FAQs</h1>
-    <Accordion title="Lorem ipsum dolor sit amet?">
-        <span> Lorem ipsum dolor sit amet adipiscing elit consectitur </span>
-    </Accordion>
+    <div class="flex flex-col gap-6">
+        <Accordion title="Lorem ipsum dolor sit amet?">
+            <span> Lorem ipsum dolor sit amet adipiscing elit consectitur </span>
+        </Accordion>
+    </div>
 </section>


### PR DESCRIPTION
This PR addresses #102.

Summary of changes:
- Create dropdown component for details / FAQ  (`Accordion`)
- Add FAQs section to Projects page with example dropdown

Points for improvement:
- [ ] Match styling to [design document](https://www.figma.com/design/nG8W0j19Al9LDgdscOqCoc/CSI?node-id=117-1158&t=x0LBjviwQw5dYaGk-1)
- [ ] Add option for dropdowns that start out as opened (`open` property)
- [ ] Add option to freeze dropdowns (`interactive` property)