### PR TITLE
feat: modify card used for projects page

### DIFF
--- a/src/lib/components/ProjectCard.svelte
+++ b/src/lib/components/ProjectCard.svelte
@@ -4,13 +4,13 @@
 </script>
 
 <div
-    class="flex h-auto w-full flex-col overflow-hidden rounded-2xl bg-csi-neutral-50 px-1 shadow-lg md:max-w-72 md:px-2 dark:bg-csi-neutral-900"
+    class="flex h-full w-full flex-col overflow-hidden rounded-2xl bg-csi-neutral-50 px-1 shadow-lg md:max-w-72 md:px-2 dark:bg-csi-neutral-900"
 >
     {#if src}
         <img {src} alt={project} loading="lazy" class="m-0 h-64 shrink-0 object-cover md:h-48" />
     {/if}
     <div class="md:text-md m-3 flex h-full flex-col justify-between gap-2 overflow-hidden">
         <h2 class="m-0">{project}</h2>
-        <p class="m-0 grow overflow-hidden">{description}</p>
+        <p class="m-0 grow overflow-hidden text-justify">{description}</p>
     </div>
 </div>

--- a/src/lib/components/ProjectCard.svelte
+++ b/src/lib/components/ProjectCard.svelte
@@ -1,16 +1,16 @@
 <script lang="ts">
     import type { Project } from '$lib/projects/projects';
-    const { src, project, type, description, href }: Project = $props();
+    const { src, project, description }: Project = $props();
 </script>
 
 <div
-    class="flex h-auto w-full flex-col overflow-hidden rounded-2xl bg-csi-neutral-50 shadow-lg md:h-[32rem] md:w-72 dark:bg-csi-neutral-900"
+    class="flex h-auto w-full flex-col overflow-hidden rounded-2xl bg-csi-neutral-50 px-1 shadow-lg md:max-w-72 md:px-2 dark:bg-csi-neutral-900"
 >
-    <img {src} alt={project} loading="lazy" class="m-0 h-64 shrink-0 object-cover md:h-48" />
-    <div class="m-3 flex h-full flex-col justify-between gap-2 overflow-hidden">
-        <p class="m-0">{type}</p>
+    {#if src}
+        <img {src} alt={project} loading="lazy" class="m-0 h-64 shrink-0 object-cover md:h-48" />
+    {/if}
+    <div class="md:text-md m-3 flex h-full flex-col justify-between gap-2 overflow-hidden">
         <h2 class="m-0">{project}</h2>
         <p class="m-0 grow overflow-hidden">{description}</p>
-        <p class="m-0"><a {href}>More Info</a></p>
     </div>
 </div>

--- a/src/lib/projects/projects.ts
+++ b/src/lib/projects/projects.ts
@@ -2,20 +2,30 @@ import lino from '$lib/lino-sablay.svg';
 
 export interface Project {
     tag: string;
-    type: string;
     project: string;
     description: string;
-    src: string;
-    href: string;
+    src?: string;
 }
 
 export default [
     {
         tag: 'Service',
-        type: 'Internal',
         project: 'Service Project',
-        description: 'Lorep ipsum.',
+        description:
+            'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.',
         src: lino,
-        href: '/projects/',
+    },
+    {
+        tag: 'Innovation',
+        project: 'Innovcamp',
+        description:
+            'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.',
+        src: lino,
+    },
+    {
+        tag: 'Innovation',
+        project: 'Kopi Korner',
+        description:
+            'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.',
     },
 ] satisfies Project[];


### PR DESCRIPTION
This PR modifies the implementation for the card component used in the `projects` route (i.e., `src/lib/components/ProjectCard.svelte`). This component was based on this [Figma](https://www.figma.com/design/nG8W0j19Al9LDgdscOqCoc/CSI) design by Judelle Gaza. I've removed the `href` and the `type` attribute in `projects.ts` since it doesn't really do anything to the component (correct me if I'm wrong). I've also made the `src` attribute optional so that cards without available pictures/images are supported.