### PR TITLE
feat(projects): fill up FAQS

### DIFF
--- a/src/routes/projects/+page.svelte
+++ b/src/routes/projects/+page.svelte
@@ -21,18 +21,39 @@
 
 <section>
     <Faq>
-        <FaqEntry title="GENERAL FAQ">
+        <FaqEntry title="What kind of projects can I commission?">
+            <span>UP CSI is open to accepting web development projects as of the moment. </span>
+        </FaqEntry>
+        <FaqEntry title="How much do projects usually cost?">
             <span
-                >Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor
-                incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
-                exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</span
+                >Costs vary depending on the scale of the project and the customer’s budget. Prices
+                are usually negotiable as projects made with UP CSI is also a way for its members to
+                practice the skills they have learned.</span
             >
         </FaqEntry>
-        <FaqEntry title="GENERAL FAQ">
+        <FaqEntry title="How do I commission a project?">
             <span
-                >Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor
-                incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
-                exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</span
+                >You may contact UP CSI by sending an email <a href="mailto:lino@up-csi.org"
+                    >here.</a
+                >
+
+                Preferably, please include the following information in your email:
+            </span>
+            <ul>
+                <li>Brief project overview</li>
+                <li>Brief features list</li>
+                <li>Other project-specific concerns</li>
+            </ul>
+            <span> UP CSI will get back to you to set an appointment within 5 business days. </span>
+        </FaqEntry>
+        <FaqEntry title="Who will work on my project?">
+            <span
+                >The Director of Engineering and the Vice President for Service decide who will work
+                on the projects. Priority is given to members who haven’t participated in a service
+                project yet. However, these members must have completed the Dev Training Program and
+                DevCamp — unless they already have sufficient development experience. UP CSI
+                members, who are mostly passionate students from the UP Diliman Department of
+                Computer Science, make up the pool of candidates for these projects.</span
             >
         </FaqEntry>
     </Faq>


### PR DESCRIPTION
This PR addresses #113 with the following changes:

- Implemented the `FaqEntry` component to populate the general FAQs.
- Each FAQ entry is sourced from the [Service Projects FAQs Google Doc](https://docs.google.com/document/d/1ToTj_l6DlYsFGosie_07WOgalok6TSJq4DK7rWcRzH8/edit?tab=t.0#heading=h.v0p1x6e5soce).