### PR TITLE
fix(ci)!: patch actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Install Latest Corepack
+        run: npm install -g corepack@latest
       - name: Enable Corepack for `pnpm`
         run: corepack enable
       - name: Get `pnpm` Store Directory

--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ Unlike `npm`, `pnpm` is fast and space-efficient. Instead of downloading an enti
 
 # Credits
 
--   This repository was originally bootstrapped by [Basti Ortiz](https://bastidood.github.io/) during the Academic Year 2023-2024 when he served as the UP CSI Director for Engineering.
-    -   Repository Setup
-    -   Automation with GitHub Actions
-    -   Original Build System with Parcel
-    -   New Build System with Vite
+- This repository was originally bootstrapped by [Basti Ortiz](https://bastidood.github.io/) during the Academic Year 2023-2024 when he served as the UP CSI Director for Engineering.
+    - Repository Setup
+    - Automation with GitHub Actions
+    - Original Build System with Parcel
+    - New Build System with Vite


### PR DESCRIPTION
As seen in #122, there was an error regarding `pnpm store path`. This PR fixes the workflow error by adding a step to the `build` job to install the latest `corepack` as recommended by this post from [Vercel](https://vercel.com/guides/corepack-errors-github-actions#quick-debug-steps).