### PR TITLE
chore: migrate hooks, layout, and build config to TypeScript; add path aliases

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,12 +1,13 @@
+import type { Handle } from '@sveltejs/kit';
 import { building } from '$app/environment';
 import { minify } from 'html-minifier';
 
-export function handle({ event, resolve }) {
+export const handle: Handle = async ({ event, resolve }) => {
     let page = '';
     return resolve(event, {
-        transformPageChunk({ html, done }) {
+        transformPageChunk({ html, done }): string | undefined {
             page += html;
-            if (done)
+            if (done) {
                 return building
                     ? minify(page, {
                           collapseWhitespace: true,
@@ -17,7 +18,7 @@ export function handle({ event, resolve }) {
                           minifyCSS: true,
                           minifyJS: false,
                           removeAttributeQuotes: true,
-                          removeComments: false, // necessary for hydration code
+                          removeComments: false, // necessary for hydration
                           removeOptionalTags: true,
                           removeRedundantAttributes: true,
                           removeScriptTypeAttributes: true,
@@ -26,6 +27,7 @@ export function handle({ event, resolve }) {
                           sortClassName: true,
                       })
                     : page;
-        },
+            }
+        }
     });
-}
+};

--- a/src/routes/+layout.js
+++ b/src/routes/+layout.js
@@ -1,2 +1,0 @@
-export const prerender = true;
-export const trailingSlash = 'always';

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -1,0 +1,2 @@
+export const prerender: boolean = true;
+export const trailingSlash: 'always' | 'never' | 'ignore' = 'always';

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -5,5 +5,12 @@ import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 export default {
     extensions: ['.svelte', '.md'],
     preprocess: vitePreprocess(),
-    kit: { adapter: adapter({ fallback: '404.html' }) },
+    kit: { 
+        adapter: adapter({ fallback: '404.html' }), 
+        alias: {
+            $lib: 'src/lib',
+            $routes: 'src/routes',
+            $static: 'static'
+        }
+    },
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,12 @@
         "skipLibCheck": true,
         "sourceMap": true,
         "strict": true,
-        "noUncheckedIndexedAccess": true
+        "noUncheckedIndexedAccess": true,
+        "paths": {
+            "$lib": ["/src/lib/*"],
+            "$routes": ["/src/routes/*"],
+            "$static": ["/static/*"]
+        }
     }
     // Path aliases are handled by https://kit.svelte.dev/docs/configuration#alias.
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,16 @@
+import path from 'path';
 import { defineConfig } from 'vite';
 import { enhancedImages } from '@sveltejs/enhanced-img';
 import { sveltekit } from '@sveltejs/kit/vite';
 import tailwindcss from '@tailwindcss/vite';
 
 export default defineConfig({
+    resolve: {
+        alias: {
+            $lib: path.resolve('src/lib'),
+            $routes: path.resolve('/src/routes'),
+            $static: path.resolve('static')
+        },
+    },
     plugins: [enhancedImages(), sveltekit(), tailwindcss()],
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
     resolve: {
         alias: {
             $lib: path.resolve('src/lib'),
-            $routes: path.resolve('/src/routes'),
+            $routes: path.resolve('src/routes'),
             $static: path.resolve('static')
         },
     },


### PR DESCRIPTION
This PR:
- Renames `hooks.server.js` → `hooks.server.ts` and types the `handle` hook.
- Converts `+layout.js`  → `+layout.ts` with explicit exports.
- Migrates `vite.config.js` → `vite.config.ts` and adds `resolve.alias`.
- Adds `paths` in `tsconfig.json`

Now you get full TypeScript support and clean imports via `$lib`,  `$routes`, and `$static`. 