### PR TITLE
feat: restyle project cards

### DIFF
--- a/src/lib/components/cards/ProjectCard.svelte
+++ b/src/lib/components/cards/ProjectCard.svelte
@@ -6,14 +6,24 @@
     }
 
     const { project }: Props = $props();
-    const { name, description }: Project = $derived(project);
+    const { tag, name, client, end_date, description }: Project = $derived(project);
+
+    function formatDate(date: Date): string {
+        return date.toLocaleDateString('en-us', { year: 'numeric', month: 'long' });
+    }
+
+    const formattedDate = $derived(end_date ? formatDate(new Date(end_date)) : '');
 </script>
 
 <div
     class="bg-float text-float-foreground flex h-full w-full flex-col overflow-hidden rounded-lg px-1 shadow-lg md:max-w-72 md:px-2"
 >
     <div class="md:text-md !m-3 flex h-full flex-col justify-between gap-2 overflow-hidden *:!m-0">
+        <div>
+            {tag}
+        </div>
         <h2>{name}</h2>
-        <p class="grow overflow-hidden text-justify">{description}</p>
+        <h4>{[client, formattedDate].filter(v => v).join(' // ')}</h4>
+        <p class="line-clamp-3 grow overflow-hidden text-justify">{description}</p>
     </div>
 </div>

--- a/src/lib/components/cards/ProjectCard.svelte
+++ b/src/lib/components/cards/ProjectCard.svelte
@@ -21,9 +21,7 @@
     <div
         class="md:text-md !m-3 flex h-full flex-col items-start justify-between gap-2 overflow-hidden *:!m-0"
     >
-        <div>
-            {tag}
-        </div>
+        <span class="bg-csi-blue-500 text-csi-black w-25 rounded-xl py-1">{tag}</span>
         <h2 class="text-left">{name}</h2>
         <p class="text-left text-lg">{[client, formattedDate].filter(v => v).join(' // ')}</p>
         <p class="line-clamp-3 grow overflow-hidden text-justify">{description}</p>

--- a/src/lib/components/cards/ProjectCard.svelte
+++ b/src/lib/components/cards/ProjectCard.svelte
@@ -16,14 +16,14 @@
 </script>
 
 <div
-    class="bg-float text-float-foreground flex h-full w-96 flex-col overflow-hidden rounded-4xl p-4 shadow-lg md:max-w-72 md:p-3"
+    class="bg-float text-float-foreground flex h-72 w-96 flex-col overflow-hidden rounded-4xl p-4 shadow-lg md:max-w-72 md:p-3"
 >
     <div
-        class="md:text-md !m-3 flex h-full flex-col items-start justify-between gap-2 overflow-hidden *:!m-0"
+        class="md:text-md !m-3 flex h-full flex-col items-start justify-start gap-2 overflow-hidden *:!m-0"
     >
         <span class="bg-csi-blue-500 text-csi-black w-25 rounded-xl py-1">{tag}</span>
         <h2 class="text-left">{name}</h2>
         <p class="text-left text-lg">{[client, formattedDate].filter(v => v).join(' // ')}</p>
-        <p class="line-clamp-3 grow overflow-hidden text-left">{description}</p>
+        <p class="line-clamp-3 overflow-hidden text-left">{description}</p>
     </div>
 </div>

--- a/src/lib/components/cards/ProjectCard.svelte
+++ b/src/lib/components/cards/ProjectCard.svelte
@@ -24,6 +24,6 @@
         <span class="bg-csi-blue-500 text-csi-black w-25 rounded-xl py-1">{tag}</span>
         <h2 class="text-left">{name}</h2>
         <p class="text-left text-lg">{[client, formattedDate].filter(v => v).join(' // ')}</p>
-        <p class="line-clamp-3 grow overflow-hidden text-justify">{description}</p>
+        <p class="line-clamp-3 grow overflow-hidden text-left">{description}</p>
     </div>
 </div>

--- a/src/lib/components/cards/ProjectCard.svelte
+++ b/src/lib/components/cards/ProjectCard.svelte
@@ -18,12 +18,14 @@
 <div
     class="bg-float text-float-foreground flex h-full w-full flex-col overflow-hidden rounded-lg px-1 shadow-lg md:max-w-72 md:px-2"
 >
-    <div class="md:text-md !m-3 flex h-full flex-col justify-between gap-2 overflow-hidden *:!m-0">
+    <div
+        class="md:text-md !m-3 flex h-full flex-col items-start justify-between gap-2 overflow-hidden *:!m-0"
+    >
         <div>
             {tag}
         </div>
-        <h2>{name}</h2>
-        <h4>{[client, formattedDate].filter(v => v).join(' // ')}</h4>
+        <h2 class="text-left">{name}</h2>
+        <p class="text-left text-lg">{[client, formattedDate].filter(v => v).join(' // ')}</p>
         <p class="line-clamp-3 grow overflow-hidden text-justify">{description}</p>
     </div>
 </div>

--- a/src/lib/components/cards/ProjectCard.svelte
+++ b/src/lib/components/cards/ProjectCard.svelte
@@ -16,7 +16,7 @@
 </script>
 
 <div
-    class="bg-float text-float-foreground flex h-full w-full flex-col overflow-hidden rounded-4xl p-4 shadow-lg md:max-w-72 md:p-3"
+    class="bg-float text-float-foreground flex h-full w-96 flex-col overflow-hidden rounded-4xl p-4 shadow-lg md:max-w-72 md:p-3"
 >
     <div
         class="md:text-md !m-3 flex h-full flex-col items-start justify-between gap-2 overflow-hidden *:!m-0"

--- a/src/lib/components/cards/ProjectCard.svelte
+++ b/src/lib/components/cards/ProjectCard.svelte
@@ -16,7 +16,7 @@
 </script>
 
 <div
-    class="bg-float text-float-foreground flex h-full w-full flex-col overflow-hidden rounded-lg px-1 shadow-lg md:max-w-72 md:px-2"
+    class="bg-float text-float-foreground flex h-full w-full flex-col overflow-hidden rounded-4xl p-4 shadow-lg md:max-w-72 md:p-3"
 >
     <div
         class="md:text-md !m-3 flex h-full flex-col items-start justify-between gap-2 overflow-hidden *:!m-0"


### PR DESCRIPTION
This should partially address #138. The components have been restyled to match the Figma.

However, I could not make the cards have a uniform width. It seems like this is handled somewhere higher up the component tree with a CSS Grid-styled component, but I don't want to touch anything I don't really understand.

If I have time later, I'll try to see if I can figure that out.

For now, this should serve as an initial draft. Sorry for the delay!