### PR TITLE
feat: add carousels and modals

### DIFF
--- a/src/lib/components/carousels/ImageCarousel.svelte
+++ b/src/lib/components/carousels/ImageCarousel.svelte
@@ -1,0 +1,153 @@
+<script lang="ts">
+    import src from '$lib/assets/lino/lino-sablay.svg';
+    import CarouselModal from '../modals/CarouselModal.svelte';
+    import Icon from '@iconify/svelte';
+    import leftArrow from '@iconify/icons-heroicons/arrow-left-circle';
+    import rightArrow from '@iconify/icons-heroicons/arrow-right-circle';
+
+    let showModal = $state(false);
+
+    let { items = [] } = $props();
+    console.log(items);
+
+    // filter items with pictures only
+    let filteredItems = $derived(items.filter(item => item.picture));
+
+    if (filteredItems.length == 0) {
+        // TODO: the following properties are highly recommended to be filled in order to have complete information
+        filteredItems = [
+            {
+                name: 'No Items Yet',
+                description: 'No items are currently in the database',
+                tag: 'General',
+                state: '',
+                type: '',
+                picture: null,
+                registerLink: '', // Optional: for events only
+                duration: '',
+            },
+        ];
+    }
+
+    let currentIndex = $state(0);
+    let currentItem = $derived(filteredItems[currentIndex]);
+
+    function nextItem() {
+        currentIndex = (currentIndex + 1) % filteredItems.length;
+    }
+
+    function prevItem() {
+        currentIndex = (currentIndex - 1 + filteredItems.length) % filteredItems.length;
+    }
+
+    function goToItem(index: number) {
+        currentIndex = index;
+    }
+</script>
+
+<!-- Add modal for every filtered item in carousel-->
+<CarouselModal
+    bind:showModal
+    {currentIndex}
+    items={filteredItems}
+    {nextItem}
+    {prevItem}
+    {goToItem}
+/>
+
+<section
+    class="font-dm mx-auto flex w-full max-w-5xl items-center justify-center gap-2 p-2 sm:gap-4"
+    id="carousel-wrapper"
+>
+    <button aria-label="Previous slide" class=" self-center p-1" onclick={prevItem}>
+        <Icon icon={leftArrow} class="hover:text-csi-blue cursor-pointer text-4xl text-gray-400 " />
+    </button>
+
+    <div class="bg-muted shadow-csi-blue-500 overflow-hidden rounded-xl shadow-sm">
+        <div
+            class="text-foreground grid grid-cols-1 items-center gap-4 rounded-xl p-4 shadow-md sm:p-6 md:grid-cols-3 md:gap-8"
+        >
+            <div class="flex items-center justify-center">
+                {#if currentItem.picture}
+                    <enhanced:img
+                        src={currentItem.picture}
+                        alt={currentItem.name}
+                        loading="lazy"
+                        class="aspect-square h-48 rounded-xl object-cover md:h-64 md:w-96"
+                    />
+                {:else}
+                    <!-- Placeholder image when events carousel is empty -->
+                    <img
+                        {src}
+                        alt="UP CSI Logo Placeholder"
+                        class="aspect-square h-48 rounded-xl object-cover md:h-64 md:w-96"
+                    />
+                {/if}
+            </div>
+            <div
+                class="grid w-full grid-rows-[30px_150px_30px] items-center gap-1 overflow-hidden py-2 text-center sm:gap-2 md:col-span-2 md:items-start md:text-left"
+            >
+                <span
+                    class="bg-csi-blue flex h-auto w-fit items-center place-self-center rounded-lg px-4 py-1 text-xs text-white shadow sm:text-sm md:place-self-start"
+                >
+                    {#if currentItem.tag}
+                        {currentItem.tag}
+                    {:else}
+                        <!--NOTE: if tag does not exist-->
+                        General
+                    {/if}
+                </span>
+                <div class="prose prose-sm mt-0 max-w-none md:mt-1">
+                    <h1 class="mt-1 mb-1 text-2xl font-bold sm:text-3xl lg:text-4xl">
+                        {currentItem.name}
+                    </h1>
+                    <p class="text-md mt-0 line-clamp-3 sm:text-lg">
+                        {currentItem.description}
+                    </p>
+                </div>
+                <div
+                    class="mb-2 flex w-full flex-wrap items-center justify-center gap-2 md:justify-start"
+                >
+                    <button
+                        onclick={() => {
+                            showModal = true;
+                        }}
+                        class="border-csi-blue text-foreground hover:bg-csi-blue hover:text-background cursor-pointer rounded-lg border px-3 py-1 text-xs no-underline hover:shadow-inner sm:text-sm"
+                    >
+                        More Info
+                    </button>
+                    {#if currentItem.state === 'Upcoming' && currentItem.registerLink}
+                        <a
+                            href="/"
+                            class=" border-csi-blue text-foreground hover:bg-csi-blue hover:text-background cursor-pointer rounded-lg border px-3 py-1 text-xs no-underline hover:shadow-inner sm:text-sm"
+                            >Register</a
+                        >
+                    {/if}
+                </div>
+            </div>
+        </div>
+
+        <div class="bg-background flex items-center justify-center space-x-3 py-4">
+            {#each filteredItems as item, i}
+                <button
+                    aria-label="Go to slide {i}"
+                    aria-current="true"
+                    onclick={() => {
+                        goToItem(i);
+                    }}
+                    class="{item == currentItem ? 'bg-csi-blue' : 'bg-gray-300'} {item !=
+                    currentItem
+                        ? 'hover:bg-gray-400'
+                        : ''} h-2.5 w-2.5 cursor-pointer rounded-full"
+                ></button>
+            {/each}
+        </div>
+    </div>
+
+    <button aria-label="Next slide" class=" self-center p-1" onclick={nextItem}>
+        <Icon
+            icon={rightArrow}
+            class="hover:text-csi-blue cursor-pointer text-4xl text-gray-400 "
+        />
+    </button>
+</section>

--- a/src/lib/components/carousels/ImageCarousel.svelte
+++ b/src/lib/components/carousels/ImageCarousel.svelte
@@ -1,19 +1,20 @@
 <script lang="ts">
-    import src from '$lib/assets/lino/lino-sablay.svg';
-    import CarouselModal from '../modals/CarouselModal.svelte';
     import Icon from '@iconify/svelte';
-    import leftArrow from '@iconify/icons-heroicons/arrow-left-circle';
-    import rightArrow from '@iconify/icons-heroicons/arrow-right-circle';
+    import LeftArrow from '@iconify/icons-heroicons/arrow-left-circle';
+    import RightArrow from '@iconify/icons-heroicons/arrow-right-circle';
+
+    import CarouselModal from '$lib/components/modals/CarouselModal.svelte';
+
+    import placeholder from '$lib/assets/lino/lino-sablay.svg';
 
     let showModal = $state(false);
 
-    let { items = [] } = $props();
-    console.log(items);
+    const { items = [] } = $props();
 
     // filter items with pictures only
     let filteredItems = $derived(items.filter(item => item.picture));
 
-    if (filteredItems.length == 0) {
+    if (filteredItems.length === 0) {
         // TODO: the following properties are highly recommended to be filled in order to have complete information
         filteredItems = [
             {
@@ -30,7 +31,7 @@
     }
 
     let currentIndex = $state(0);
-    let currentItem = $derived(filteredItems[currentIndex]);
+    const currentItem = $derived(filteredItems[currentIndex]);
 
     function nextItem() {
         currentIndex = (currentIndex + 1) % filteredItems.length;
@@ -60,7 +61,7 @@
     id="carousel-wrapper"
 >
     <button aria-label="Previous slide" class=" self-center p-1" onclick={prevItem}>
-        <Icon icon={leftArrow} class="hover:text-csi-blue cursor-pointer text-4xl text-gray-400 " />
+        <Icon icon={LeftArrow} class="hover:text-csi-blue cursor-pointer text-4xl text-gray-400 " />
     </button>
 
     <div class="bg-muted shadow-csi-blue-500 overflow-hidden rounded-xl shadow-sm">
@@ -78,7 +79,7 @@
                 {:else}
                     <!-- Placeholder image when events carousel is empty -->
                     <img
-                        {src}
+                        src={placeholder}
                         alt="UP CSI Logo Placeholder"
                         class="aspect-square h-48 rounded-xl object-cover md:h-64 md:w-96"
                     />
@@ -135,7 +136,7 @@
                     onclick={() => {
                         goToItem(i);
                     }}
-                    class="{item == currentItem ? 'bg-csi-blue' : 'bg-gray-300'} {item !=
+                    class="{item === currentItem ? 'bg-csi-blue' : 'bg-gray-300'} {item !==
                     currentItem
                         ? 'hover:bg-gray-400'
                         : ''} h-2.5 w-2.5 cursor-pointer rounded-full"
@@ -146,7 +147,7 @@
 
     <button aria-label="Next slide" class=" self-center p-1" onclick={nextItem}>
         <Icon
-            icon={rightArrow}
+            icon={RightArrow}
             class="hover:text-csi-blue cursor-pointer text-4xl text-gray-400 "
         />
     </button>

--- a/src/lib/components/items/EventItem.svelte
+++ b/src/lib/components/items/EventItem.svelte
@@ -2,6 +2,7 @@
     import type { Event } from '$lib/models/event';
 
     import Card from '$lib/components/cards/EventCard.svelte';
+    import EventModal from '$lib/components/modals/EventModal.svelte';
 
     interface Props {
         event: Event;
@@ -16,6 +17,7 @@
     onclick={() => {
         modalOpen = true;
     }}
+    class="cursor-pointer"
 >
     <Card {event} />
 </button>
@@ -26,6 +28,6 @@
             ? 'block'
             : 'hidden'}"
     >
-        <!-- TODO: insert modal here -->
+        <EventModal bind:showModal={modalOpen} currentItem={event} />
     </div>
 </div>

--- a/src/lib/components/items/ProjectItem.svelte
+++ b/src/lib/components/items/ProjectItem.svelte
@@ -2,6 +2,7 @@
     import type { Project } from '$lib/models/project';
 
     import Card from '$lib/components/cards/ProjectCard.svelte';
+    import ProjectModal from '$lib/components/modals/ProjectModal.svelte';
 
     interface Props {
         project: Project;
@@ -16,6 +17,7 @@
     onclick={() => {
         modalOpen = true;
     }}
+    class="cursor-pointer"
 >
     <Card {project} />
 </button>
@@ -26,6 +28,6 @@
             ? 'block'
             : 'hidden'}"
     >
-        <!-- TODO: insert modal here -->
+        <ProjectModal bind:showModal={modalOpen} currentItem={project} />
     </div>
 </div>

--- a/src/lib/components/modals/CarouselModal.svelte
+++ b/src/lib/components/modals/CarouselModal.svelte
@@ -1,0 +1,167 @@
+<script lang="ts">
+    import Icon from '@iconify/svelte';
+    import src from '$lib/assets/lino/lino-sablay.svg';
+    import leftArrow from '@iconify/icons-heroicons/arrow-left-circle';
+    import rightArrow from '@iconify/icons-heroicons/arrow-right-circle';
+    import closeIcon from '@iconify/icons-heroicons/x-mark';
+    import { scale } from 'svelte/transition';
+
+    let {
+        showModal = $bindable(),
+        currentIndex = $bindable(),
+        items = [],
+        nextItem,
+        prevItem,
+        goToItem,
+    } = $props();
+
+    let currentItem = $derived(items[currentIndex]);
+    let dialogRef:HTMLDialogElement | undefined= $state();
+
+    $effect(() => {
+        if (dialogRef) {
+            if (showModal && !dialogRef.open) {
+                dialogRef.showModal();
+            }
+        }
+    });
+
+    function requestDialogClose() {
+        showModal = false;
+    }
+
+    function handleNativeDialogClose() {
+        if (showModal) {
+            showModal = false;
+        }
+    }
+
+    function handleDialogCancel(item: Event) {
+        item.preventDefault();
+        requestDialogClose();
+    }
+
+    function handleBackdropClick(item: Event) {
+        if (item.target === dialogRef) {
+            requestDialogClose();
+        }
+    }
+</script>
+
+{#if showModal}
+    <dialog
+        bind:this={dialogRef}
+        onclose={handleNativeDialogClose}
+        oncancel={handleDialogCancel}
+        onmousedown={handleBackdropClick}
+        class="font-dm shadow-csi-blue text-foreground bg-background mx-auto my-auto h-4/5 w-3/4 overflow-y-auto rounded-3xl p-0 shadow-md sm:w-2/3 md:w-3/5 lg:w-1/2"
+        in:scale={{ duration: 200, start: 0.95, opacity: 0.75 }}
+        out:scale={{ duration: 150, start: 0.95 }}
+    >
+        <div class=" flex flex-col gap-2 overflow-y-auto sm:p-4">
+            <div class="mx-8 mt-4 flex items-start justify-between">
+                <div class="flex flex-wrap gap-2">
+                    {#if currentItem.state}
+                        <span
+                            class="bg-csi-blue flex h-auto w-fit items-center rounded-lg px-4 py-1 text-xs font-semibold text-white shadow sm:text-sm"
+                            >{currentItem.state}</span
+                        >
+                    {/if}
+                    {#if currentItem.tag}
+                        <span
+                            class="bg-csi-blue flex h-auto w-fit items-center rounded-lg px-4 py-1 text-xs font-semibold text-white shadow sm:text-sm"
+                            >{currentItem.tag}</span
+                        >
+                    {/if}
+                    {#if currentItem.type}
+                        <span
+                            class="bg-csi-blue flex h-auto w-fit items-center rounded-lg px-4 py-1 text-xs font-semibold text-white shadow sm:text-sm"
+                            >{currentItem.type}</span
+                        >
+                    {/if}
+                </div>
+                <div class="ml-2">
+                    <button
+                        aria-label="Close Modal"
+                        onclick={requestDialogClose}
+                        class="p-1 text-gray-500 hover:text-gray-700"
+                    >
+                        <Icon icon={closeIcon} class="h-6 w-6 cursor-pointer" />
+                    </button>
+                </div>
+            </div>
+
+            <div class="mx-8 flex flex-col md:text-lg">
+                <h1 class=" text-xl font-bold sm:text-2xl md:text-4xl">{currentItem.name}</h1>
+                <p class=" sm:text-md text-sm md:text-lg">
+                    {#if currentItem.duration}
+                        {currentItem.duration}
+                    {:else}
+                        No data available for duration
+                    {/if}
+                </p>
+            </div>
+
+            <div class="grid grid-cols-[50px_1fr_50px] grid-rows-[1fr_50px] py-2">
+                <button
+                    aria-label="Previous slide"
+                    class="col-start-1 row-start-2 flex-none shrink-0 self-center p-1 md:row-start-1"
+                    onclick={prevItem}
+                >
+                    <Icon
+                        icon={leftArrow}
+                        class="hover:text-csi-blue mr-2 cursor-pointer text-4xl "
+                    />
+                </button>
+                <div class="col-span-3 mx-4 md:col-span-1 md:mx-0">
+                    {#if currentItem.picture}
+                        <enhanced:img
+                            {src}
+                            alt="dummy"
+                            loading="lazy"
+                            class="m-0 aspect-square w-full rounded-xl object-cover md:h-90"
+                        />
+                    {:else}
+                        <img
+                            {src}
+                            alt="UP CSI Logo Placeholder"
+                            class="m-0 aspect-square w-full rounded-xl object-cover md:h-90"
+                        />
+                    {/if}
+                </div>
+                <div
+                    class="bg-background col-span-1 col-start-2 row-start-2 flex items-center justify-center space-x-3 pt-4 md:col-span-3 md:col-start-1"
+                >
+                    {#each items as item, i}
+                        <button
+                            aria-label="Go to slide {i}"
+                            aria-current="true"
+                            onclick={() => {
+                                goToItem(i);
+                            }}
+                            class="{item == currentItem ? 'bg-csi-blue' : 'bg-gray-300'} {item !=
+                            currentItem
+                                ? 'hover:bg-gray-400'
+                                : ''} focus-visible:ring-csi-blue focus-visible:ring-offset-muted h-2.5 w-2.5 cursor-pointer rounded-full focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
+                        ></button>
+                    {/each}
+                </div>
+                <button
+                    aria-label="Next slide"
+                    class="col-start-3 row-start-2 flex-none shrink-0 self-center p-1 md:row-start-1"
+                    onclick={nextItem}
+                >
+                    <Icon
+                        icon={rightArrow}
+                        class="hover:text-csi-blue ml-2 cursor-pointer text-4xl  "
+                    />
+                </button>
+            </div>
+            <div class="mx-8 mt-4 flex items-start justify-between">
+                <p class=" sm:text-md text-sm md:text-lg">
+                    {currentItem.description}
+                </p>
+            </div>
+        </div>
+    </dialog>
+{/if}

--- a/src/lib/components/modals/CarouselModal.svelte
+++ b/src/lib/components/modals/CarouselModal.svelte
@@ -1,11 +1,14 @@
 <script lang="ts">
+    import CloseIcon from '@iconify/icons-heroicons/x-mark';
     import Icon from '@iconify/svelte';
-    import src from '$lib/assets/lino/lino-sablay.svg';
-    import leftArrow from '@iconify/icons-heroicons/arrow-left-circle';
-    import rightArrow from '@iconify/icons-heroicons/arrow-right-circle';
-    import closeIcon from '@iconify/icons-heroicons/x-mark';
+    import LeftArrow from '@iconify/icons-heroicons/arrow-left-circle';
+    import RightArrow from '@iconify/icons-heroicons/arrow-right-circle';
+
     import { scale } from 'svelte/transition';
 
+    import placeholder from '$lib/assets/lino/lino-sablay.svg';
+
+    // eslint-disable-next-line
     let {
         showModal = $bindable(),
         currentIndex = $bindable(),
@@ -15,8 +18,8 @@
         goToItem,
     } = $props();
 
-    let currentItem = $derived(items[currentIndex]);
-    let dialogRef:HTMLDialogElement | undefined= $state();
+    const currentItem = $derived(items[currentIndex]);
+    let dialogRef: HTMLDialogElement | undefined = $state();
 
     $effect(() => {
         if (dialogRef) {
@@ -86,7 +89,7 @@
                         onclick={requestDialogClose}
                         class="p-1 text-gray-500 hover:text-gray-700"
                     >
-                        <Icon icon={closeIcon} class="h-6 w-6 cursor-pointer" />
+                        <Icon icon={CloseIcon} class="h-6 w-6 cursor-pointer" />
                     </button>
                 </div>
             </div>
@@ -109,21 +112,21 @@
                     onclick={prevItem}
                 >
                     <Icon
-                        icon={leftArrow}
+                        icon={LeftArrow}
                         class="hover:text-csi-blue mr-2 cursor-pointer text-4xl "
                     />
                 </button>
                 <div class="col-span-3 mx-4 md:col-span-1 md:mx-0">
                     {#if currentItem.picture}
                         <enhanced:img
-                            {src}
+                            src={currentItem.picture}
                             alt="dummy"
                             loading="lazy"
                             class="m-0 aspect-square w-full rounded-xl object-cover md:h-90"
                         />
                     {:else}
                         <img
-                            {src}
+                            src={placeholder}
                             alt="UP CSI Logo Placeholder"
                             class="m-0 aspect-square w-full rounded-xl object-cover md:h-90"
                         />
@@ -139,7 +142,7 @@
                             onclick={() => {
                                 goToItem(i);
                             }}
-                            class="{item == currentItem ? 'bg-csi-blue' : 'bg-gray-300'} {item !=
+                            class="{item === currentItem ? 'bg-csi-blue' : 'bg-gray-300'} {item !==
                             currentItem
                                 ? 'hover:bg-gray-400'
                                 : ''} focus-visible:ring-csi-blue focus-visible:ring-offset-muted h-2.5 w-2.5 cursor-pointer rounded-full focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
@@ -152,7 +155,7 @@
                     onclick={nextItem}
                 >
                     <Icon
-                        icon={rightArrow}
+                        icon={RightArrow}
                         class="hover:text-csi-blue ml-2 cursor-pointer text-4xl  "
                     />
                 </button>

--- a/src/lib/components/modals/EventModal.svelte
+++ b/src/lib/components/modals/EventModal.svelte
@@ -1,12 +1,15 @@
 <script lang="ts">
+    import CloseIcon from '@iconify/icons-heroicons/x-mark';
     import Icon from '@iconify/svelte';
-    import src from '$lib/assets/lino/lino-sablay.svg';
-    import closeIcon from '@iconify/icons-heroicons/x-mark';
+
     import { scale } from 'svelte/transition';
 
+    import placeholder from '$lib/assets/lino/lino-sablay.svg';
+
+    // eslint-disable-next-line
     let { showModal = $bindable(), currentItem } = $props();
 
-    let dialogRef:HTMLDialogElement | undefined = $state();
+    let dialogRef: HTMLDialogElement | undefined = $state();
 
     $effect(() => {
         if (dialogRef) {
@@ -36,7 +39,6 @@
             requestDialogClose();
         }
     }
-
 </script>
 
 {#if showModal}
@@ -77,12 +79,12 @@
                         onclick={requestDialogClose}
                         class="p-1 text-gray-500 hover:text-gray-700"
                     >
-                        <Icon icon={closeIcon} class="h-6 w-6 cursor-pointer" />
+                        <Icon icon={CloseIcon} class="h-6 w-6 cursor-pointer" />
                     </button>
                 </div>
             </div>
 
-            <div class="mx-8 *:!my-0 flex flex-col md:text-lg">
+            <div class="mx-8 flex flex-col *:!my-0 md:text-lg">
                 <h1 class=" text-xl font-bold sm:text-2xl md:text-4xl">{currentItem.name}</h1>
                 <p class=" sm:text-md text-sm md:text-lg">
                     {#if currentItem.duration}
@@ -96,14 +98,14 @@
             <div class="col-span-3 mx-4 md:col-span-1 md:mx-0">
                 {#if currentItem.picture}
                     <enhanced:img
-                        {src}
+                        src={currentItem.picture}
                         alt="dummy"
                         loading="lazy"
                         class="m-0 aspect-square w-full rounded-xl object-cover md:h-90"
                     />
                 {:else}
                     <img
-                        {src}
+                        src={placeholder}
                         alt="UP CSI Logo Placeholder"
                         class="m-0 aspect-square w-full rounded-xl object-cover md:h-90"
                     />

--- a/src/lib/components/modals/EventModal.svelte
+++ b/src/lib/components/modals/EventModal.svelte
@@ -1,0 +1,119 @@
+<script lang="ts">
+    import Icon from '@iconify/svelte';
+    import src from '$lib/assets/lino/lino-sablay.svg';
+    import closeIcon from '@iconify/icons-heroicons/x-mark';
+    import { scale } from 'svelte/transition';
+
+    let { showModal = $bindable(), currentItem } = $props();
+
+    let dialogRef:HTMLDialogElement | undefined = $state();
+
+    $effect(() => {
+        if (dialogRef) {
+            if (showModal && !dialogRef.open) {
+                dialogRef.showModal();
+            }
+        }
+    });
+
+    function requestDialogClose() {
+        showModal = false;
+    }
+
+    function handleNativeDialogClose() {
+        if (showModal) {
+            showModal = false;
+        }
+    }
+
+    function handleDialogCancel(item: Event) {
+        item.preventDefault();
+        requestDialogClose();
+    }
+
+    function handleBackdropClick(item: Event) {
+        if (item.target === dialogRef) {
+            requestDialogClose();
+        }
+    }
+
+</script>
+
+{#if showModal}
+    <dialog
+        bind:this={dialogRef}
+        onclose={handleNativeDialogClose}
+        oncancel={handleDialogCancel}
+        onmousedown={handleBackdropClick}
+        class="font-dm shadow-csi-blue text-foreground bg-background mx-auto my-auto h-4/5 w-3/4 overflow-y-auto rounded-3xl p-0 shadow-md sm:w-2/3 md:w-3/5 lg:w-1/2"
+        in:scale={{ duration: 200, start: 0.95, opacity: 0.75 }}
+        out:scale={{ duration: 150, start: 0.95 }}
+    >
+        <div class=" flex flex-col gap-2 overflow-y-auto sm:p-4">
+            <div class="mx-8 mt-4 flex items-start justify-between">
+                <div class="flex flex-wrap gap-2">
+                    {#if currentItem.state}
+                        <span
+                            class="bg-csi-blue flex h-auto w-fit items-center rounded-lg px-4 py-1 text-xs font-semibold text-white shadow sm:text-sm"
+                            >{currentItem.state}</span
+                        >
+                    {/if}
+                    {#if currentItem.tag}
+                        <span
+                            class="bg-csi-blue flex h-auto w-fit items-center rounded-lg px-4 py-1 text-xs font-semibold text-white shadow sm:text-sm"
+                            >{currentItem.tag}</span
+                        >
+                    {/if}
+                    {#if currentItem.type}
+                        <span
+                            class="bg-csi-blue flex h-auto w-fit items-center rounded-lg px-4 py-1 text-xs font-semibold text-white shadow sm:text-sm"
+                            >{currentItem.type}</span
+                        >
+                    {/if}
+                </div>
+                <div class="ml-2">
+                    <button
+                        aria-label="Close Modal"
+                        onclick={requestDialogClose}
+                        class="p-1 text-gray-500 hover:text-gray-700"
+                    >
+                        <Icon icon={closeIcon} class="h-6 w-6 cursor-pointer" />
+                    </button>
+                </div>
+            </div>
+
+            <div class="mx-8 *:!my-0 flex flex-col md:text-lg">
+                <h1 class=" text-xl font-bold sm:text-2xl md:text-4xl">{currentItem.name}</h1>
+                <p class=" sm:text-md text-sm md:text-lg">
+                    {#if currentItem.duration}
+                        {currentItem.duration}
+                    {:else}
+                        No data available for duration
+                    {/if}
+                </p>
+            </div>
+
+            <div class="col-span-3 mx-4 md:col-span-1 md:mx-0">
+                {#if currentItem.picture}
+                    <enhanced:img
+                        {src}
+                        alt="dummy"
+                        loading="lazy"
+                        class="m-0 aspect-square w-full rounded-xl object-cover md:h-90"
+                    />
+                {:else}
+                    <img
+                        {src}
+                        alt="UP CSI Logo Placeholder"
+                        class="m-0 aspect-square w-full rounded-xl object-cover md:h-90"
+                    />
+                {/if}
+            </div>
+            <div class="mx-8 mt-4 flex items-start justify-between">
+                <p class=" sm:text-md text-sm md:text-lg">
+                    {currentItem.description}
+                </p>
+            </div>
+        </div>
+    </dialog>
+{/if}

--- a/src/lib/components/modals/ProjectModal.svelte
+++ b/src/lib/components/modals/ProjectModal.svelte
@@ -1,12 +1,15 @@
 <script lang="ts">
+    import CloseIcon from '@iconify/icons-heroicons/x-mark';
     import Icon from '@iconify/svelte';
-    import src from '$lib/assets/lino/lino-sablay.svg';
-    import closeIcon from '@iconify/icons-heroicons/x-mark';
+
     import { scale } from 'svelte/transition';
 
+    import placeholder from '$lib/assets/lino/lino-sablay.svg';
+
+    // eslint-disable-next-line
     let { showModal = $bindable(), currentItem } = $props();
 
-    let dialogRef:HTMLDialogElement | undefined = $state();
+    let dialogRef: HTMLDialogElement | undefined = $state();
 
     $effect(() => {
         if (dialogRef) {
@@ -26,7 +29,7 @@
         }
     }
 
-    function handleDialogCancel(item : Event) {
+    function handleDialogCancel(item: Event) {
         item.preventDefault();
         requestDialogClose();
     }
@@ -76,7 +79,7 @@
                         onclick={requestDialogClose}
                         class="p-1 text-gray-500 hover:text-gray-700"
                     >
-                        <Icon icon={closeIcon} class="h-6 w-6 cursor-pointer" />
+                        <Icon icon={CloseIcon} class="h-6 w-6 cursor-pointer" />
                     </button>
                 </div>
             </div>
@@ -95,14 +98,14 @@
             <div class=" mx-4 md:mx-0">
                 {#if currentItem.picture}
                     <enhanced:img
-                        {src}
+                        src={currentItem.picture}
                         alt="dummy"
                         loading="lazy"
                         class="m-0 aspect-square w-full rounded-xl object-cover md:h-90"
                     />
                 {:else}
                     <img
-                        {src}
+                        src={placeholder}
                         alt="UP CSI Logo Placeholder"
                         class="m-0 aspect-square w-full rounded-xl object-cover md:h-90"
                     />

--- a/src/lib/components/modals/ProjectModal.svelte
+++ b/src/lib/components/modals/ProjectModal.svelte
@@ -1,0 +1,118 @@
+<script lang="ts">
+    import Icon from '@iconify/svelte';
+    import src from '$lib/assets/lino/lino-sablay.svg';
+    import closeIcon from '@iconify/icons-heroicons/x-mark';
+    import { scale } from 'svelte/transition';
+
+    let { showModal = $bindable(), currentItem } = $props();
+
+    let dialogRef:HTMLDialogElement | undefined = $state();
+
+    $effect(() => {
+        if (dialogRef) {
+            if (showModal && !dialogRef.open) {
+                dialogRef.showModal();
+            }
+        }
+    });
+
+    function requestDialogClose() {
+        showModal = false;
+    }
+
+    function handleNativeDialogClose() {
+        if (showModal) {
+            showModal = false;
+        }
+    }
+
+    function handleDialogCancel(item : Event) {
+        item.preventDefault();
+        requestDialogClose();
+    }
+
+    function handleBackdropClick(item: Event) {
+        if (item.target === dialogRef) {
+            requestDialogClose();
+        }
+    }
+</script>
+
+{#if showModal}
+    <dialog
+        bind:this={dialogRef}
+        onclose={handleNativeDialogClose}
+        oncancel={handleDialogCancel}
+        onmousedown={handleBackdropClick}
+        class="font-dm shadow-csi-blue text-foreground bg-background mx-auto my-auto h-4/5 w-3/4 rounded-3xl p-0 shadow-md sm:w-2/3 md:w-3/5 lg:w-1/2"
+        in:scale={{ duration: 200, start: 0.95, opacity: 0.75 }}
+        out:scale={{ duration: 150, start: 0.95 }}
+    >
+        <div class=" flex flex-col sm:p-4">
+            <div class="mx-8 mt-4 flex items-start justify-between">
+                <div class="flex flex-wrap gap-2">
+                    {#if currentItem.state}
+                        <span
+                            class="bg-csi-blue flex h-auto w-fit items-center rounded-lg px-4 py-1 text-xs font-semibold text-white shadow sm:text-sm"
+                            >{currentItem.state}</span
+                        >
+                    {/if}
+                    {#if currentItem.tag}
+                        <span
+                            class="bg-csi-blue flex h-auto w-fit items-center rounded-lg px-4 py-1 text-xs font-semibold text-white shadow sm:text-sm"
+                            >{currentItem.tag}</span
+                        >
+                    {/if}
+                    {#if currentItem.type}
+                        <span
+                            class="bg-csi-blue flex h-auto w-fit items-center rounded-lg px-4 py-1 text-xs font-semibold text-white shadow sm:text-sm"
+                            >{currentItem.type}</span
+                        >
+                    {/if}
+                </div>
+                <div class="ml-2">
+                    <button
+                        aria-label="Close Modal"
+                        onclick={requestDialogClose}
+                        class="p-1 text-gray-500 hover:text-gray-700"
+                    >
+                        <Icon icon={closeIcon} class="h-6 w-6 cursor-pointer" />
+                    </button>
+                </div>
+            </div>
+
+            <div class="mx-8 flex flex-col *:!my-0">
+                <h1 class=" text-xl font-bold sm:text-2xl md:text-4xl">{currentItem.name}</h1>
+                <p class=" sm:text-md text-sm md:text-lg">
+                    {#if currentItem.duration}
+                        {currentItem.duration}
+                    {:else}
+                        No data available for duration
+                    {/if}
+                </p>
+            </div>
+
+            <div class=" mx-4 md:mx-0">
+                {#if currentItem.picture}
+                    <enhanced:img
+                        {src}
+                        alt="dummy"
+                        loading="lazy"
+                        class="m-0 aspect-square w-full rounded-xl object-cover md:h-90"
+                    />
+                {:else}
+                    <img
+                        {src}
+                        alt="UP CSI Logo Placeholder"
+                        class="m-0 aspect-square w-full rounded-xl object-cover md:h-90"
+                    />
+                {/if}
+            </div>
+            <div class="mx-8 mt-4 flex items-start justify-between">
+                <p class=" sm:text-md text-sm md:text-lg">
+                    {currentItem.description}
+                </p>
+            </div>
+        </div>
+    </dialog>
+{/if}

--- a/src/routes/events/+page.svelte
+++ b/src/routes/events/+page.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
     import Events from '$lib/components/panels/EventPanel.svelte';
+    import ImageCarousel from '$lib/components/carousels/ImageCarousel.svelte';
 
     const { data } = $props();
     const { events, filteredEvents } = $derived(data);
 </script>
 
+<ImageCarousel items={events} />
 <section class="prose">
     <Events {events} {filteredEvents} />
 </section>


### PR DESCRIPTION
This PR adds the image carousels and modals for the carousel, event and project items.

Notes:
- `eslint-disable-next-line` was used for props in modals due to contradicting errors in ESLint (one variable should be `let` and the others should be `const`, but `$props()` can only be called once)
- used lino-sablay as placeholder image