### PR TITLE
perf: lazy load member images

### DIFF
--- a/src/lib/components/cards/MemberCard.svelte
+++ b/src/lib/components/cards/MemberCard.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-    import { fade } from 'svelte/transition';
     import type { EnhancedImgAttributes } from '@sveltejs/enhanced-img';
+    import { fade } from 'svelte/transition';
 
     import type { BoardOfficer } from '$lib/types/board_officer';
     import type { Member } from '$lib/models/member';

--- a/src/lib/components/cards/MemberCard.svelte
+++ b/src/lib/components/cards/MemberCard.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import { fade } from 'svelte/transition';
+    import type { EnhancedImgAttributes } from '@sveltejs/enhanced-img';
 
     import type { BoardOfficer } from '$lib/types/board_officer';
     import type { Member } from '$lib/models/member';
@@ -14,7 +15,15 @@
     }
 
     const { member, socials, color, foreground }: Props = $props();
-    const { name, src, title } = $derived(member);
+    const { name, title, img } = $derived(member);
+
+    async function getImg() {
+        const imgImport = await import(`$lib/assets/team/${img}.webp?enhanced?url`);
+        const src: EnhancedImgAttributes['src'] = imgImport.default;
+
+        return src;
+    }
+
     let isOverlayVisible = $state(false);
 </script>
 
@@ -25,30 +34,32 @@
     onmouseenter={() => (isOverlayVisible = true)}
     onmouseleave={() => (isOverlayVisible = false)}
 >
-    <enhanced:img
-        {src}
-        alt={name}
-        height="300px"
-        loading="lazy"
-        class="col-start-1 row-start-1 !m-0 aspect-square h-56 w-full rounded-2xl object-cover md:h-full"
-    />
-    {#if isOverlayVisible}
-        <div
-            class="bg-csi-black/70 text-csi-white absolute z-10 col-start-1 row-start-1 hidden h-full w-full flex-col justify-end gap-2 p-4 md:flex"
-            transition:fade={{ duration: 75 }}
-        >
-            <MemberCardTag {name} {title} {socials} />
-        </div>
-    {:else}
-        <div
-            class="absolute z-10 col-start-1 row-start-1 hidden h-full w-full flex-col justify-end p-1 md:flex"
-            in:fade={{ duration: 75 }}
-        >
-            <div class="h-fit w-fit rounded-full px-3 py-1 {color}">
-                <p class="{foreground} !m-0 text-sm">{name}</p>
+    {#await getImg() then src}
+        <enhanced:img
+            {src}
+            alt={name}
+            height="300px"
+            loading="lazy"
+            class="col-start-1 row-start-1 !m-0 aspect-square h-56 w-full rounded-2xl object-cover md:h-full"
+        />
+        {#if isOverlayVisible}
+            <div
+                class="bg-csi-black/70 text-csi-white absolute z-10 col-start-1 row-start-1 hidden h-full w-full flex-col justify-end gap-2 p-4 md:flex"
+                transition:fade={{ duration: 75 }}
+            >
+                <MemberCardTag {name} {title} {socials} />
             </div>
-        </div>
-    {/if}
+        {:else}
+            <div
+                class="absolute z-10 col-start-1 row-start-1 hidden h-full w-full flex-col justify-end p-1 md:flex"
+                in:fade={{ duration: 75 }}
+            >
+                <div class="h-fit w-fit rounded-full px-3 py-1 {color}">
+                    <p class="{foreground} !m-0 text-sm">{name}</p>
+                </div>
+            </div>
+        {/if}
+    {/await}
 
     <div class="col-start-1 row-start-2 flex flex-col gap-2 md:hidden">
         <MemberCardTag {name} {title} {socials} />

--- a/src/lib/data/exec/index.ts
+++ b/src/lib/data/exec/index.ts
@@ -46,14 +46,14 @@ export async function getExec() {
     const officers = await getOfficers();
     const boards: Record<string, Board> = {};
 
-    officers.forEach(({ name, src, parsed_pos }) => {
+    officers.forEach(({ name, img, parsed_pos }) => {
         const { last_name, nickname } = name;
         const officer_name = `${nickname} ${last_name}`;
 
         Object.keys(parsed_pos).forEach(term => {
             const title = parsed_pos[term];
             if (title) {
-                const new_officer: BoardOfficer = { name: officer_name, src, title };
+                const new_officer: BoardOfficer = { name: officer_name, img, title };
 
                 if (!boards[term]) {
                     const new_board: Board = { term, src: null, officers: [] };

--- a/src/lib/data/exec/index.ts
+++ b/src/lib/data/exec/index.ts
@@ -1,5 +1,3 @@
-import type { EnhancedImgAttributes } from '@sveltejs/enhanced-img';
-
 import { parse } from 'valibot';
 
 import { type Officer, Officer as OfficerSchema } from '$lib/models/officer';
@@ -14,10 +12,6 @@ async function getOfficers() {
 
     const promises = Object.entries(imports).map(async ([_, asset]) => {
         const officer = parse(OfficerSchema, await asset());
-
-        const src: EnhancedImgAttributes['src'] = (
-            await import(`$lib/assets/exec/${officer.img}.webp?enhanced?url`)
-        ).default;
 
         const parsed_pos: Record<string, Position[]> = {};
 
@@ -35,7 +29,7 @@ async function getOfficers() {
             }
         });
 
-        const parsed_officer: Officer = { ...officer, parsed_pos, src };
+        const parsed_officer: Officer = { ...officer, parsed_pos };
         return parsed_officer;
     });
 

--- a/src/lib/data/team/index.ts
+++ b/src/lib/data/team/index.ts
@@ -1,5 +1,3 @@
-import type { EnhancedImgAttributes } from '@sveltejs/enhanced-img';
-
 import { parse } from 'valibot';
 
 import { type Member, Member as MemberSchema } from '$lib/models/member';
@@ -8,13 +6,8 @@ export async function getTeam() {
     const imports = import.meta.glob<Member>('./json/*.json');
 
     const promises = Object.entries(imports).map(async ([_, asset]) => {
-        const member = parse(MemberSchema, await asset());
-        const src: EnhancedImgAttributes['src'] = (
-            await import(`$lib/assets/team/${member.img}.webp?enhanced?url`)
-        ).default;
-
-        const parsed_member: Member = { ...member, src };
-        return parsed_member;
+        const member: Member = parse(MemberSchema, await asset());
+        return member;
     });
 
     return await Promise.all(promises);

--- a/src/lib/models/member.ts
+++ b/src/lib/models/member.ts
@@ -1,5 +1,3 @@
-import type { EnhancedImgAttributes } from '@sveltejs/enhanced-img';
-
 import { type InferOutput, array, object, optional, picklist, record, string } from 'valibot';
 
 import { MemberCommittees } from '$lib/types/committees';
@@ -14,6 +12,4 @@ export const Member = object({
     socials: optional(record(picklist(Object.keys(MemberSocialMedia)), string())),
 });
 
-export interface Member extends InferOutput<typeof Member> {
-    src: EnhancedImgAttributes['src'];
-}
+export type Member = InferOutput<typeof Member>;

--- a/src/lib/models/officer.ts
+++ b/src/lib/models/officer.ts
@@ -1,5 +1,3 @@
-import type { EnhancedImgAttributes } from '@sveltejs/enhanced-img';
-
 import { type InferOutput, array, object, string } from 'valibot';
 
 import type { Position } from '$lib/models/position';

--- a/src/lib/models/officer.ts
+++ b/src/lib/models/officer.ts
@@ -14,6 +14,5 @@ export const Officer = object({
 });
 
 export interface Officer extends InferOutput<typeof Officer> {
-    src: EnhancedImgAttributes['src'];
     parsed_pos: Record<string, Position[]>;
 }

--- a/src/lib/types/board_officer.ts
+++ b/src/lib/types/board_officer.ts
@@ -1,9 +1,7 @@
-import type { EnhancedImgAttributes } from '@sveltejs/enhanced-img';
-
 import type { Position } from '$lib/models/position';
 
 export interface BoardOfficer {
     name: string;
-    src: EnhancedImgAttributes['src'];
+    img: string;
     title: Position[];
 }


### PR DESCRIPTION
This PR uses dynamic imports to lazy load the images in the People Page, resulting in a faster page load. However, images don't load _agad_.